### PR TITLE
[HOTFIX] Change overlooked category_id to categories

### DIFF
--- a/recommender/services/fts.py
+++ b/recommender/services/fts.py
@@ -7,7 +7,7 @@ from recommender.models import Service
 
 def retrieve_services(search_data):
     """Applies search info from MP and filters MongoDB by them"""
-    category_id = search_data.get("category_id")
+    categories = search_data.get("categories")
     countries = search_data.get("geographical_availabilities")
     provider_ids = search_data.get("providers")
     search_phrase = search_data.get("q")
@@ -15,7 +15,7 @@ def retrieve_services(search_data):
     scientific_domain_ids = search_data.get("scientific_domains")
     target_user_ids = search_data.get("target_users")
     q = Service.objects
-    q = q(categories__in=[category_id]) if category_id is not None else q
+    q = q(categories__in=categories) if categories is not None else q
     q = q(countries__in=countries) if countries else q
     q = q(providers__in=provider_ids) if provider_ids else q
     q = q(platforms__in=platform_ids) if platform_ids else q

--- a/tests/endpoints/test_recommendations.py
+++ b/tests/endpoints/test_recommendations.py
@@ -17,7 +17,7 @@ def recommendation_data():
         "panel_id": "v1",
         "search_data": {
             "q": "Cloud GPU",
-            "category_id": 1,
+            "categories": [1],
             "geographical_availabilities": ["PL"],
             "order_type": "open_access",
             "providers": [1],

--- a/tests/services/test_fts.py
+++ b/tests/services/test_fts.py
@@ -50,8 +50,8 @@ def test_retrieve_services(mongo, mocker):
     assert [x.id for x in retrieve_services({"q": "EGI"})] == [0, 1]
     search_text_mock.assert_called_once_with("EGI")
 
-    assert [x.id for x in retrieve_services({"category_id": 0})] == [0]
-    assert [x.id for x in retrieve_services({"category_id": 1})] == [0, 1]
+    assert [x.id for x in retrieve_services({"categories": [0]})] == [0]
+    assert [x.id for x in retrieve_services({"categories": [1]})] == [0, 1]
     assert [x.id for x in retrieve_services({"countries": ["PL", "WW", "EU"]})] == [
         0,
         1,
@@ -70,8 +70,8 @@ def test_retrieve_services(mongo, mocker):
     assert [x.id for x in retrieve_services({"target_users": [2]})] == [1]
     assert [x.id for x in retrieve_services({"target_users": [3]})] == []
     assert [
-        x.id for x in retrieve_services({"category_id": 0, "target_users": [2]})
+        x.id for x in retrieve_services({"categories": [0], "target_users": [2]})
     ] == []
     assert [
-        x.id for x in retrieve_services({"category_id": 1, "target_users": [2]})
+        x.id for x in retrieve_services({"categories": [1], "target_users": [2]})
     ] == [1]


### PR DESCRIPTION
There were overlloked `category_id` that should be changed to `categories` in #48 