### PR TITLE
[HOTFIX] fix AGENT_VERSION default in execute_training task

### DIFF
--- a/recommender/tasks/neural_networks.py
+++ b/recommender/tasks/neural_networks.py
@@ -18,7 +18,7 @@ from recommender.extensions import celery
 
 @celery.task
 def execute_training(_=None):
-    agent_version = dotenv_values(find_dotenv())["AGENT_VERSION"]
+    agent_version = dotenv_values(find_dotenv()).get("AGENT_VERSION")
     trainings = {PRE_AGENT: pre_agent_training, RL_AGENT: rl_agent_training}
     training = trainings.get(agent_version, pre_agent_training)
     training()


### PR DESCRIPTION
In execute_training task, AGENT_VERSION variable had been accessed from dictionary in insecure way: no default handling - it has been fixed.