### PR TITLE
[#257] Add useful flask commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD
 ### Added
-
+- Flask CLI commands (testing db seed, execution of individual AI pipelines and more) [@wujuu]
 ### Changed
 
 ### Fixed

--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -16,7 +16,7 @@ from recommender.api import api
 from recommender.models import User
 from settings import config_by_name
 
-from .commands import seed_faker, train_rl_pipeline, execute_pipelines
+from .commands import seed_faker, seed_db, execute_training, drop_mp_dump_task
 
 
 def create_app():
@@ -42,13 +42,18 @@ def _register_commands(app):
     def seed_faker_command():
         seed_faker()
 
-    @app.cli.command("train_rl_pipeline")
-    def rl_pipeline_command():
-        train_rl_pipeline()
+    @app.cli.command("seed_mp_dump")
+    def seed_mp_dump_command():
+        seed_db()
 
-    @app.cli.command("execute_pipelines")
-    def execute_pipelines_command():
-        execute_pipelines()
+    @app.cli.command("drop_mp_dump")
+    def drop_mp_dump_command():
+        drop_mp_dump_task()
+
+    @app.cli.command("execute_training")
+    @click.argument("task")
+    def execute_training_command(task):
+        execute_training(task)
 
 
 def _register_extensions(app):

--- a/recommender/commands.py
+++ b/recommender/commands.py
@@ -1,10 +1,5 @@
-# pylint: disable=expression-not-assigned, fixme, missing-function-docstring
+"""Module for the flask CLI commands"""
 
-"""This module contains logic for seeding factories fakers.
- To make factories more realistic you can use seed_faker function
- to generate special json files from data existing in the database.
- These files will contain information used by factories' fakers
- to generate more realistic data"""
 from recommender.engines.autoencoders.inference.embedding_component import (
     EmbeddingComponent,
 )
@@ -29,40 +24,74 @@ from recommender.pipeline_configs import (
     NCF_PIPELINE_CONFIG,
     RL_PIPELINE_CONFIG_V2,
 )
+from recommender.services.mp_dump import drop_mp_dump
 
 from tests.factories.marketplace.faker_seeds.utils.dumpers import (
     dump_names_descs,
     dump_names,
     dump_taglines,
 )
-
-NAMES_DESCS_CLASSES = [
-    Service,
-    AccessMode,
-    AccessType,
-    LifeCycleStatus,
-    TargetUser,
-    Trl,
-]
-NAMES_CLASSES = [Category, Platform, Provider, ScientificDomain]
+from tests.factories.populate_database import populate_users_and_services
 
 
 def seed_faker():
-    """Call this function to generate json files used for seeding fakers in factories.
-    It uses current database data for it."""
-    [dump_names_descs(clazz) for clazz in NAMES_DESCS_CLASSES]
-    [dump_names(clazz) for clazz in NAMES_CLASSES]
+    """
+    Call this function to generate json files used for seeding fakers in factories.
+    It uses current database data for it. To make factories more
+    realistic you can use seed_faker function to generate special
+    json files from data existing in the database.
+    These files will contain information used by factories'
+    fakers to generate more realistic data
+    """
+    names_descs_classes = [
+        Service,
+        AccessMode,
+        AccessType,
+        LifeCycleStatus,
+        TargetUser,
+        Trl,
+    ]
+    class_names = [Category, Platform, Provider, ScientificDomain]
+
+    for clazz in names_descs_classes:
+        dump_names_descs(clazz)
+    for clazz in class_names:
+        dump_names(clazz)
 
     dump_taglines()
 
 
-def execute_pipelines():
-    AEPipeline(AUTOENCODERS_PIPELINE_CONFIG)()
-    EmbeddingComponent()()
-    NCFPipeline(NCF_PIPELINE_CONFIG)()
-    RLPipeline(RL_PIPELINE_CONFIG_V1)()
-    RLPipeline(RL_PIPELINE_CONFIG_V2)()
+def execute_training(task):
+    """Runs given machine learning task"""
+    if task == "ae":
+        AEPipeline(AUTOENCODERS_PIPELINE_CONFIG)()
+    elif task == "embedding":
+        EmbeddingComponent()()
+    elif task == "ncf":
+        NCFPipeline(NCF_PIPELINE_CONFIG)()
+    elif task == "rl":
+        RLPipeline(RL_PIPELINE_CONFIG_V1)()
+    elif task == "all":
+        AEPipeline(AUTOENCODERS_PIPELINE_CONFIG)()
+        EmbeddingComponent()()
+        NCFPipeline(NCF_PIPELINE_CONFIG)()
+        RLPipeline(RL_PIPELINE_CONFIG_V1)()
+        RLPipeline(RL_PIPELINE_CONFIG_V2)()
 
 
-def train_rl_pipeline():
-    RLPipeline(RL_PIPELINE_CONFIG_V1)()
+def seed_db():
+    """Populates databse with a small amount of data
+    for testing and development purposes"""
+    populate_users_and_services(
+        common_services_no=30,
+        unordered_services_no=70,
+        total_users=100,
+        k_common_services_max=10,
+        k_common_services_min=1,
+        verbose=True,
+    )
+
+
+def drop_mp_dump_task():
+    """Drops the documents sent by the MP Database dump"""
+    drop_mp_dump()

--- a/tests/engine/preprocessing/test_preprocessing.py
+++ b/tests/engine/preprocessing/test_preprocessing.py
@@ -104,9 +104,9 @@ def test_precalculate_tensors(mongo):
 
 def test_precalc_users_and_service_tensors(mongo):
     populate_users_and_services(
-        common_services_number=4,
-        no_one_services_number=1,
-        users_number=4,
+        common_services_no=4,
+        unordered_services_no=1,
+        total_users=4,
         k_common_services_min=1,
         k_common_services_max=3,
     )

--- a/tests/engines/conftest.py
+++ b/tests/engines/conftest.py
@@ -51,9 +51,9 @@ from tests.factories.populate_database import populate_users_and_services
 @pytest.fixture
 def generate_data(mongo):
     populate_users_and_services(
-        common_services_number=9,
-        no_one_services_number=9,
-        users_number=5,
+        common_services_no=9,
+        unordered_services_no=9,
+        total_users=5,
         k_common_services_min=5,
         k_common_services_max=7,
     )

--- a/tests/factories/populate_database.py
+++ b/tests/factories/populate_database.py
@@ -10,20 +10,20 @@ from tests.factories.marketplace import ServiceFactory, UserFactory
 
 
 def populate_users_and_services(
-    common_services_number,
-    no_one_services_number,
-    users_number,
+    common_services_no,
+    unordered_services_no,
+    total_users,
     k_common_services_min,
     k_common_services_max,
     verbose=False,
 ):
-    """Populate database with users and their accessed (or not) services"""
+    """Populate database with users and their ordered (or not) services"""
 
-    _no_one_services = [
+    _unordered_services = [
         ServiceFactory()
         for _ in trange(
-            no_one_services_number,
-            desc="No one services creating...",
+            unordered_services_no,
+            desc="Creating unordered services...",
             disable=(not verbose),
         )
     ]
@@ -31,14 +31,14 @@ def populate_users_and_services(
     common_services = [
         ServiceFactory()
         for _ in trange(
-            common_services_number,
-            desc="Common services creating...",
+            common_services_no,
+            desc="Creating common services ...",
             disable=(not verbose),
         )
     ]
 
-    for _ in trange(users_number, desc="Users creating...", disable=(not verbose)):
+    for _ in trange(total_users, desc="Creating users...", disable=(not verbose)):
         k = random.randint(k_common_services_min, k_common_services_max)
         accessed_services = random.sample(common_services, k=k)
-        user = UserFactory(accessed_services=accessed_services)
+        user = UserFactory(accessed_services=accessed_services, synthetic=True)
         user.save()


### PR DESCRIPTION
Commands added:
- seed_db - to seed the database with mock data for training convenience
- execute_training - to manually trigger one or all ML pipelines
- drop_db - drop marketplace documents form our mongodb

Closes #257. 