### PR TITLE
[#282] SARSes regeneration

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pipenv run pytest tests/
+        pipenv run pytest -n auto
 
     - name: Lint with pylint
       run: |

--- a/.run/Flask (app.py).run.xml
+++ b/.run/Flask (app.py).run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Flask (app.py)" type="Python.FlaskServer" nameIsGenerated="true">
+  <configuration default="false" name="Flask (app.py:app)" type="Python.FlaskServer" nameIsGenerated="true">
+    <option name="application" value="app" />
     <option name="flaskDebug" value="true" />
     <module name="recommender-system" />
     <option name="target" value="$PROJECT_DIR$/app.py" />
@@ -9,9 +10,9 @@
     <envs>
       <env name="FLASK_ENV" value="development" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-r71yvAN0/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />

--- a/.run/celery worker.run.xml
+++ b/.run/celery worker.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="celery worker" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="Celery Worker" type="PythonConfigurationType" factoryName="Python">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
@@ -7,7 +7,7 @@
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="FLASK_ENV" value="development" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-r71yvAN0/bin/python" />
+    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-EpR-2lwc/bin/python" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
@@ -24,10 +24,10 @@
         <ENTRY IS_ENABLED="true" PARSER="env" PATH=".env" />
       </ENTRIES>
     </EXTENSION>
-    <option name="SCRIPT_NAME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-r71yvAN0/bin/celery" />
+    <option name="SCRIPT_NAME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-EpR-2lwc/bin/celery" />
     <option name="PARAMETERS" value="-A worker:app worker --loglevel=info --concurrency=1" />
     <option name="SHOW_COMMAND_LINE" value="false" />
-    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="EMULATE_TERMINAL" value="true" />
     <option name="MODULE_MODE" value="false" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />

--- a/.run/coverage run --source=. -m pytest ..run.xml
+++ b/.run/coverage run --source=. -m pytest ..run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="coverage run --source=. -m pytest ." type="PythonConfigurationType" factoryName="Python" nameIsGenerated="true">
+  <configuration default="false" name="Test coverage" type="PythonConfigurationType" factoryName="Python">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />

--- a/.run/hyperparameters_tuning.run.xml
+++ b/.run/hyperparameters_tuning.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="hyperparameters_tuning" type="PythonConfigurationType" factoryName="Python" nameIsGenerated="true">
+  <configuration default="false" name="Hyperparameters Tuning" type="PythonConfigurationType" factoryName="Python">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />

--- a/.run/pytest in tests 10 CPUs.run.xml
+++ b/.run/pytest in tests 10 CPUs.run.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="pytest in tests on max CPUs" type="tests" factoryName="py.test">
+  <configuration default="false" name="Pytest on max CPUs" type="tests" factoryName="py.test">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="FLASK_ENV" value="testing" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-r71yvAN0/bin/python" />
+    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-EpR-2lwc/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
@@ -24,7 +24,7 @@
     </EXTENSION>
     <option name="_new_keywords" value="&quot;&quot;" />
     <option name="_new_parameters" value="&quot;&quot;" />
-    <option name="_new_additionalArguments" value="&quot;-n auto&quot;" />
+    <option name="_new_additionalArguments" value="&quot;-n auto --randomly-seed\u003d1234&quot;" />
     <option name="_new_target" value="&quot;$PROJECT_DIR$/tests&quot;" />
     <option name="_new_targetType" value="&quot;PATH&quot;" />
     <method v="2" />

--- a/.run/pytest in tests.run.xml
+++ b/.run/pytest in tests.run.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="pytest in tests" type="tests" factoryName="py.test" nameIsGenerated="true">
+  <configuration default="false" name="Pytest" type="tests" factoryName="py.test">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="FLASK_ENV" value="testing" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/recommender-system-r71yvAN0/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />

--- a/.run/simulation.run.xml
+++ b/.run/simulation.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="simulation" type="PythonConfigurationType" factoryName="Python" nameIsGenerated="true">
+  <configuration default="false" name="Simulation" type="PythonConfigurationType" factoryName="Python">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />

--- a/.run/tensorboard.run.xml
+++ b/.run/tensorboard.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="tensorboard" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="Tensorboard" type="PythonConfigurationType" factoryName="Python">
     <module name="recommender-system" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add MongoDB to CI and to testing environment [@wujuu]
 - Add adjustable min/max numerical boundaries on Actor output [@wujuu]
 - Add more tests to RLInferenceComponent [@wujuu]
+- Reimplementation SARSes (re)generation [@JanKapala]
+- DB indexes [@JanKapala]
+- Support for multiprocessing-capable code testing and parallel tests [@JanKapala]
+- Implement user journey creator for testing purposes [@JanKapala]
+- User user journey visualizer [@JanKapala]
+- Add pytest-randomly [@JanKapala]
 
 ### Changed
 

--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -41,7 +41,10 @@ def create_app():
 
 def _register_commands(app):
     @app.cli.command("db")
-    @click.argument("task", type=click.Choice(["seed", "drop_mp", "seed_faker"]))
+    @click.argument(
+        "task",
+        type=click.Choice(["seed", "drop_mp", "seed_faker", "regenerate_sarses"]),
+    )
     def tmp_db_command(task):
         db_command(task)
 

--- a/recommender/commands/db.py
+++ b/recommender/commands/db.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring
 
 """Flask CLI db commands"""
-
+from recommender.engines.rl.ml_components.sarses_generator import regenerate_sarses
 from recommender.models import (
     AccessMode,
     Service,
@@ -67,6 +67,14 @@ def _seed_faker():
         dump_names(clazz)
 
     dump_taglines()
+
+
+def _regenerate_sarses():
+    """Regenerate SARSes"""
+
+    print("Regenerating SARSes...")
+    regenerate_sarses(multi_processing=True, verbose=True)
+    print("SARSes regenerated successfully!")
 
 
 def db_command(task):

--- a/recommender/engines/autoencoders/training/data_preparation_step.py
+++ b/recommender/engines/autoencoders/training/data_preparation_step.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, no-self-use
 # pylint: disable=redefined-builtin, no-member, not-callable
-# pylint: disable=line-too-long, no-else-return
+# pylint: disable=line-too-long, no-else-return, too-many-branches
 
 """Autoencoder Data Preparation Step."""
 

--- a/recommender/engines/ncf/inference/ncf_inference_component.py
+++ b/recommender/engines/ncf/inference/ncf_inference_component.py
@@ -1,5 +1,5 @@
 # pylint: disable=unused-argument, too-few-public-methods, missing-class-docstring, missing-function-docstring
-# pylint: disable=no-self-use, superfluous-parens, no-else-return, no-member, line-too-long
+# pylint: disable=no-self-use, superfluous-parens, no-else-return, no-member, not-callable, line-too-long
 
 """Neural Collaborative Filtering Inference Component"""
 

--- a/recommender/engines/ncf/training/data_preparation_step.py
+++ b/recommender/engines/ncf/training/data_preparation_step.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments, fixme
+# pylint: disable=too-many-arguments, not-callable, fixme
 
 """Neural Collaborative Filtering Data Preparation Step."""
 

--- a/recommender/engines/rl/ml_components/reward_encoder.py
+++ b/recommender/engines/rl/ml_components/reward_encoder.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring, no-member, redefined-outer-name, too-few-public-methods
+# pylint: disable=missing-function-docstring, no-member, redefined-outer-name, too-few-public-methods, not-callable
 
 """Implementation of the Reward Encoder"""
 

--- a/recommender/engines/rl/training/data_extraction_step/data_extraction_step.py
+++ b/recommender/engines/rl/training/data_extraction_step/data_extraction_step.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-module-docstring, missing-class-docstring, invalid-name
+# pylint: disable=missing-module-docstring, missing-class-docstring, invalid-name, not-callable
 
 from time import time
 from typing import Tuple, List
@@ -12,7 +12,7 @@ from recommender.engines.rl.ml_components.synthetic_dataset.rewards import (
     RewardGeneration,
 )
 from recommender.models import Sars, UserAction, Recommendation
-from recommender.engines.rl.ml_components.sarses_generator import generate_sarses
+from recommender.engines.rl.ml_components.sarses_generator import regenerate_sarses
 from recommender.engines.rl.ml_components.synthetic_dataset.dataset import (
     generate_synthetic_sarses,
 )
@@ -63,7 +63,7 @@ class RLDataExtractionStep(DataExtractionStep):
             service_embedder = Embedder.load(version=SERVICE_EMBEDDER)
             return generate_synthetic_sarses(service_embedder, **self.synthetic_params)
 
-        real_sarses = generate_sarses(multi_processing=False)
+        real_sarses = regenerate_sarses(multi_processing=True, verbose=False)
         real_sarses = real_sarses(__raw__={"action": {"$size": self.K}})
 
         return list(real_sarses)

--- a/recommender/engines/rl/utils.py
+++ b/recommender/engines/rl/utils.py
@@ -44,8 +44,8 @@ def _generate_tree(user_action: UserAction, graph: Digraph) -> Digraph:
 
     ua_svid, ua_tvid = _get_visit_ids(user_action)
 
-    graph.node(ua_svid, label=ua_svid[:3])
-    graph.node(ua_tvid, label=ua_tvid[:3])
+    graph.node(ua_svid, label=ua_svid[:5])
+    graph.node(ua_tvid, label=ua_tvid[:5])
     if user_action.action.order:
         color = "red"
         label = "Order"
@@ -53,7 +53,7 @@ def _generate_tree(user_action: UserAction, graph: Digraph) -> Digraph:
         color = "black"
         label = ""
 
-    if user_action.source.root is not None:
+    if user_action.source.root.type == "recommendation_panel":
         service_id = user_action.source.root.service.id
         label = f"service id: {service_id}"
         color = "green"

--- a/recommender/models/recommendation.py
+++ b/recommender/models/recommendation.py
@@ -7,6 +7,7 @@ from mongoengine import (
     StringField,
     ListField,
     UUIDField,
+    BooleanField,
 )
 
 from .user import User
@@ -24,3 +25,13 @@ class Recommendation(Document):
     engine_version = StringField()
     services = ListField(ReferenceField(Service))
     search_data = ReferenceField(SearchData)
+    processed = BooleanField(blank=True)
+
+    meta = {
+        "indexes": [
+            "visit_id",
+            "user",
+            "unique_id",
+            "timestamp",
+        ]
+    }

--- a/recommender/models/sars.py
+++ b/recommender/models/sars.py
@@ -8,6 +8,7 @@ from mongoengine import (
     BooleanField,
 )
 
+from .recommendation import Recommendation
 from .service import Service
 from .state import State
 
@@ -18,3 +19,4 @@ class Sars(Document):
     reward = ListField(ListField(StringField()))
     next_state = ReferenceField(State)
     synthetic = BooleanField(default=False)
+    source_recommendation = ReferenceField(Recommendation, blank=True)

--- a/recommender/models/user.py
+++ b/recommender/models/user.py
@@ -23,3 +23,5 @@ class User(MarketplaceDocument):
     dataframe = BinaryField(blank=True)
     one_hot_tensor = ListField(IntField(), blank=True)
     dense_tensor = ListField(FloatField(), blank=True)
+
+    meta = {"indexes": ["id"]}

--- a/recommender/models/user_action.py
+++ b/recommender/models/user_action.py
@@ -6,6 +6,7 @@ from mongoengine import (
     DateTimeField,
     EmbeddedDocumentField,
     UUIDField,
+    BooleanField,
 )
 
 from .action import Action
@@ -21,3 +22,14 @@ class UserAction(Document):
     source = EmbeddedDocumentField(Source)
     target = EmbeddedDocumentField(Target)
     action = EmbeddedDocumentField(Action)
+    processed = BooleanField(default=False)
+
+    meta = {
+        "indexes": [
+            ("source.visit_id", "source.root.service"),
+            "user",
+            "unique_id",
+            "timestamp",
+            "source.root.type",
+        ]
+    }

--- a/tests/migrate/test_base_migration.py
+++ b/tests/migrate/test_base_migration.py
@@ -41,4 +41,4 @@ def test_pymongo_db_var(mongo, mock_migrations_dir):
     db_details = uri_parser.parse_uri(uri)["nodelist"][0]
 
     assert migration.pymongo_db.client.address == db_details
-    assert migration.pymongo_db.name == "test"
+    assert migration.pymongo_db.name[:4] == "test"

--- a/tests/services/test_sarses_generator.py
+++ b/tests/services/test_sarses_generator.py
@@ -1,10 +1,24 @@
 # pylint: disable-all
+import random
 
+from dotenv import load_dotenv
+
+load_dotenv()
+import pytest
+from tqdm.auto import trange
+
+from recommender import User
+from recommender.engines.panel_id_to_services_number_mapping import PANEL_ID_TO_K
+from recommender.utils import visualize_uas
+from tests.services.user_journey import UserJourney
 from tests.factories.marketplace import UserFactory
 from tests.factories.recommendation import RecommendationFactory, faker
 from tests.factories.user_action import UserActionFactory
-from recommender.engines.rl.ml_components.sarses_generator import generate_sarses
-from recommender.models import Sars, UserAction
+from recommender.engines.rl.ml_components.sarses_generator import (
+    generate_sarses,
+    regenerate_sarses,
+)
+from recommender.models import Sars, UserAction, Recommendation, Service
 from recommender.engines.rl.ml_components.reward_mapping import ua_to_reward_id
 from recommender.engines.rl.ml_components.sarses_generator import (
     RECOMMENDATION_PAGES_IDS,
@@ -19,7 +33,7 @@ def ruas2services(ruas):
     return [rua.source.root.service for rua in ruas]
 
 
-class TestSarsesGenerator:
+class TestGenerateSarses:
     def test_tree_colapse(self, mongo):
         # Zero level
         root_ua = UserActionFactory(recommendation_root=True)
@@ -300,3 +314,194 @@ class TestSarsesGenerator:
             ],
         ]
         assert sars.next_state.services_history == clicked_before + clicked_after
+
+
+class TestRegenerateSarses:
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    def test_zero_case(self, mongo, multi_processing):
+        regenerate_sarses(multi_processing=multi_processing)
+        assert Sars.objects.count() == 0
+
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    @pytest.mark.parametrize("collection", [User, Service, Sars])
+    def test_missing_data_case(self, mongo, multi_processing, collection):
+        j = UserJourney()
+        j.go_to_panel()
+
+        regenerate_sarses(multi_processing=multi_processing)
+        assert Sars.objects.count() == 1
+        original_sars_id = Sars.objects.first().id
+
+        j.next()
+        collection.drop_collection()
+        regenerate_sarses(multi_processing=multi_processing)
+
+        assert Sars.objects.count() == 0 or (
+            Sars.objects.count() == 1 and Sars.objects.first().id != original_sars_id
+        )
+
+    @pytest.mark.parametrize("anonymous", [True, False])
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    @pytest.mark.parametrize("panel_id", list(PANEL_ID_TO_K.keys()))
+    def test_minimal_case(self, mongo, anonymous, multi_processing, panel_id):
+        UserFactory()  # User necessary for assertion in the `_get_empty_user` function
+        UserJourney(anonymous=anonymous, panel_id=panel_id).go_to_panel()
+        # visualize_uas(save=True) # Uncomment for visual debugging
+
+        regenerate_sarses(multi_processing=multi_processing)
+        assert Sars.objects.count() == 1
+
+    @pytest.mark.parametrize("anonymous", [True, False])
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    @pytest.mark.parametrize("panel_id", list(PANEL_ID_TO_K.keys()))
+    def test_case_with_uas(self, mongo, anonymous, multi_processing, panel_id):
+        UserFactory()  # User necessary for assertion in the `_get_empty_user` function
+
+        j = UserJourney(anonymous=anonymous, panel_id=panel_id)
+        recommendation = Recommendation.objects(visit_id=j.lluj.last_visit_id).first()
+        for k in range(len(recommendation.services)):
+            j2 = j.service(k)
+        j2.go_to_panel()
+        regenerate_sarses(multi_processing=multi_processing)
+
+        assert Sars.objects.count() == 1
+
+    @pytest.mark.parametrize("anonymous", [True, False])
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    @pytest.mark.parametrize("panel_id", list(PANEL_ID_TO_K.keys()))
+    def test_uas_based_regeneration_scenario(
+        self, mongo, anonymous, multi_processing, panel_id
+    ):
+        # Check if sars is regenerated if there are new user actions for the sars's recommendation
+        UserFactory()  # User necessary for assertion in the `_get_empty_user` function
+
+        j = UserJourney(anonymous=anonymous, panel_id=panel_id)
+        recommendation = Recommendation.objects(visit_id=j.lluj.last_visit_id).first()
+        for k in range(len(recommendation.services)):
+            j2 = j.service(k)
+        j2.go_to_panel()
+
+        # Check if regeneration change `processed` status of recommendations and user actions
+        assert all([rec.processed in [False, None] for rec in Recommendation.objects])
+        assert all([ua.processed in [False, None] for ua in UserAction.objects])
+        regenerate_sarses(multi_processing=multi_processing)
+        assert all([rec.processed for rec in Recommendation.objects])
+        assert all([ua.processed is True for ua in UserAction.objects])
+
+        # Create a chain of user actions that is rooted in the recommendation
+        for _ in range(3):
+            original_sars_id = (
+                Sars.objects(source_recommendation=recommendation).first().id
+            )
+            j = j.next()
+
+            # Check if chained user action is processed
+            ua = UserAction.objects(target__visit_id=j.lluj.last_visit_id).first()
+            assert ua.processed in [False, None]
+            regenerate_sarses(multi_processing=multi_processing)
+            assert ua.reload().processed is True
+
+            regenerated_sars_id = (
+                Sars.objects(source_recommendation=recommendation).first().id
+            )
+
+            # visualize_uas(save=True)  # Uncomment for visual debugging
+
+            # Check if sars is regenerated
+            assert original_sars_id != regenerated_sars_id
+            assert Sars.objects.count() == 1
+
+    @pytest.mark.parametrize("anonymous", [True, False])
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    @pytest.mark.parametrize("panel_id", list(PANEL_ID_TO_K.keys()))
+    def test_multiple_users_and_recommendations_scenario(
+        self, mongo, anonymous, multi_processing, panel_id
+    ):
+        UserFactory()  # User necessary for assertion in the `_get_empty_user` function
+
+        j1 = UserJourney(anonymous=anonymous, panel_id=panel_id)
+        source_rec_j1 = Recommendation.objects(visit_id=j1.lluj.last_visit_id).first()
+        j1.service(0).next(2).order().go_to_panel()
+
+        j2 = UserJourney(anonymous=anonymous, panel_id=panel_id)
+        source_rec_j2 = Recommendation.objects(visit_id=j2.lluj.last_visit_id).first()
+        j2_1 = j2.service(0)
+        j2_1.next(3).order().go_to_panel()
+        j2_1.next(2)
+        # visualize_uas(save=True) # Uncomment for visual debugging
+
+        regenerate_sarses(multi_processing=multi_processing)
+
+        # After first regeneration there should be two sarses
+        assert Sars.objects.count() == 2
+        original_sars_j1_id = (
+            Sars.objects(source_recommendation=source_rec_j1).first().id
+        )
+        original_sars_j2_id = (
+            Sars.objects(source_recommendation=source_rec_j2).first().id
+        )
+
+        j1_1 = j1.service(1).next(2)
+        j1_1_1 = j1_1.order()
+        j1_1.next(3)
+        j1_1.next(1)
+
+        j2.service(1).next().order()
+        # visualize_uas(save=True) # Uncomment for visual debugging
+
+        regenerate_sarses(multi_processing=multi_processing)
+        regenerated_sars_j1_id = (
+            Sars.objects(source_recommendation=source_rec_j1).first().id
+        )
+        regenerated_sars_j2_id = (
+            Sars.objects(source_recommendation=source_rec_j2).first().id
+        )
+
+        # After second regeneration all sarses should be regenerated due to new user actions
+        assert Sars.objects.count() == 2
+        assert original_sars_j1_id != regenerated_sars_j1_id
+        assert original_sars_j2_id != regenerated_sars_j2_id
+
+        j1_1_1.go_to_panel()
+        # visualize_uas(save=True) # Uncomment for visual debugging
+
+        regenerate_sarses(multi_processing=multi_processing)
+        regenerated_sars_j1_after_id = (
+            Sars.objects(source_recommendation=source_rec_j1).first().id
+        )
+        regenerated_sars_j2_after_id = (
+            Sars.objects(source_recommendation=source_rec_j2).first().id
+        )
+
+        # After third regeneration only sars related to the first recommendation should be regenerated
+        # because only in it's recommendation's user actions tree there are new user actions.
+        assert regenerated_sars_j1_id != regenerated_sars_j1_after_id
+        assert regenerated_sars_j2_id == regenerated_sars_j2_after_id
+
+    @pytest.mark.skip(
+        reason="Needs significant amount of time (7min 21s on 12core i7 machine). Un-skip if needed"
+    )
+    @pytest.mark.parametrize("multi_processing", [True, False])
+    def test_heavy_load_scenario(self, mongo, multi_processing):
+        # Integration test that check if regenerate_sarses is not failing on
+        # complex users journeys scenario with multiple
+        # anonymous and logged users
+        for i in trange(10):
+            if i % 2 == 0:
+                anonymous = True
+            else:
+                anonymous = False
+            j = UserJourney(anonymous=anonymous)
+            r = Recommendation.objects(visit_id=j.lluj.last_visit_id).first()
+            for _ in trange(5, leave=False):
+                ua = j.lluj.click_random_ua_from_rec_tree(r, n=6)
+                j.lluj.go_to_rec_page(ua)
+                js = [j.service() for _ in range(3)]
+                j2 = js[0].next(random.randint(1, 4)).order().go_to_panel()
+                j3 = js[1].next(random.randint(1, 4)).go_to_panel()
+                j.next(1).order().go_to_panel()
+                j.next(2).order().next(1).go_to_panel()
+                j.next(3).order().next(1)
+            j.lluj.go_to_rec_page(start_ua=ua)
+
+        regenerate_sarses(multi_processing=multi_processing, verbose=False)

--- a/tests/services/user_journey.py
+++ b/tests/services/user_journey.py
@@ -1,0 +1,259 @@
+# pylint: disable-all
+
+"""User Journey module"""
+
+import random
+import uuid
+from copy import deepcopy
+
+from mongoengine import connect, disconnect
+from pymongo import uri_parser
+
+from tests.factories.marketplace import UserFactory
+from tests.factories.recommendation import RecommendationFactory
+from tests.factories.user_action import UserActionFactory
+from recommender.models import Recommendation, UserAction
+from settings import TestingConfig
+
+
+class LowLevelUserJourney:
+    # TODO: Refactor whole class
+
+    def __init__(self, anonymous=False, user=None, unique_id=None, panel_id="v1"):
+        if anonymous:
+            if user is not None:
+                raise Exception(
+                    "Provided user for anonymous user. For anonymous user only"
+                    " unique_id can be provided."
+                )
+            unique_id = unique_id or uuid.uuid4()
+            self.user_params = {"user": None, "unique_id": unique_id}
+        else:
+            if unique_id is not None:
+                raise Exception(
+                    "Provided unique_id for logged user. For logged user only"
+                    " user can be provided."
+                )
+            user = user or UserFactory()
+            self.user_params = {"user": user, "unique_id": None}
+        self.panel_id = {panel_id: True}
+
+        ua = UserActionFactory(**self.user_params)
+        rec = RecommendationFactory(
+            **self.user_params, **self.panel_id, visit_id=ua.target.visit_id
+        )
+        self.last_visit_id = rec.visit_id
+
+    def go_to_rec_page(self, start_ua=None):
+        """ua-->recommendation"""
+
+        if start_ua is None:
+            start_visit_id = self.last_visit_id
+        else:
+            start_visit_id = start_ua.target.visit_id
+
+        ua = UserActionFactory(**self.user_params, source__visit_id=start_visit_id)
+        recommendation = RecommendationFactory(
+            **self.user_params, **self.panel_id, visit_id=ua.target.visit_id
+        )
+        self.last_visit_id = recommendation.visit_id
+
+        return recommendation
+
+    def uas_chain(self, n: int, start_ua: UserAction = None) -> UserAction:
+        """ua-->ua-->ua-->...-->ua"""
+
+        assert n > 0
+
+        if start_ua is None:
+            visit_id = self.last_visit_id
+        else:
+            visit_id = start_ua.target.visit_id
+
+        ua = None
+        for _ in range(n):
+            ua = UserActionFactory(**self.user_params, source__visit_id=visit_id)
+            visit_id = ua.target.visit_id
+
+        self.last_visit_id = ua.target.visit_id
+
+        return ua
+
+    def click_random_service_from_rec(self, recommendation):
+        k = random.randint(0, len(recommendation.services) - 1)
+        return self.click_service_from_rec(k, recommendation)
+
+    def click_service_from_rec(self, k, recommendation):
+        """
+                             +-->service1-->[ua]
+                           /
+            recommendation+----->service2-->[ua]
+                          \
+                           +---->service3-->[ua]
+        """
+        try:
+            service = recommendation.services[k]
+        except IndexError as e:
+            raise Exception(
+                f"This recommendation has {len(recommendation.services)}"
+                f" services. Choose appropriate index."
+            ) from e
+
+        ua = UserActionFactory(
+            **self.user_params,
+            source__visit_id=recommendation.visit_id,
+            recommendation_root=True,
+            source__root__service=service,
+        )
+        self.last_visit_id = ua.target.visit_id
+
+        return ua
+
+    def click_random_ua_from_rec_tree(self, recommendation, order=False, n=1):
+        """
+                             +-->ua
+                           /
+            recommendation+---->ua-->ua-->ua-->ua
+                          \            \
+                           +-->ua       +-->ua
+        """
+
+        all_uas = self._get_all_uas_of_the_rec(recommendation)
+        if len(all_uas) > 0:
+            for _ in range(n):
+                ua = random.choice(list(all_uas))
+                ua = UserActionFactory(
+                    **self.user_params, order=order, source__visit_id=ua.target.visit_id
+                )
+        else:
+            if order:
+                raise Exception("Can't order directly from recommendation panel")
+            for _ in range(n):
+                ua = UserActionFactory(
+                    **self.user_params,
+                    order=order,
+                    source__visit_id=recommendation.visit_id,
+                )
+        self.last_visit_id = ua.target.visit_id
+
+        return ua
+
+    def _get_all_uas_of_the_rec(self, rec):
+        """get all uas of the rec, but do not traverse through order actions"""
+
+        all_uas = set()
+
+        last_uas = set(
+            UserAction.objects(**self.user_params, source__visit_id=rec.visit_id)
+        )
+        all_uas |= last_uas
+        while last_uas:
+            next_uas = set()
+            for rec_ua in last_uas:
+                next_uas |= set(
+                    UserAction.objects(
+                        **self.user_params, source__visit_id=rec_ua.target.visit_id
+                    )
+                )
+            all_uas |= next_uas
+            last_uas = set(
+                filter(
+                    lambda ua: not ua.action.order
+                    and Recommendation.objects(
+                        **self.user_params, visit_id=ua.target.visit_id
+                    ).first()
+                    is not None,
+                    next_uas,
+                )
+            )
+
+        return all_uas
+
+    def order(self, start_ua=None):
+        """ua-->order_ua"""
+
+        if start_ua is None:
+            rec = Recommendation.objects(visit_id=self.last_visit_id).first()
+            if rec is not None:
+                ua = UserActionFactory(
+                    **self.user_params,
+                    source__visit_id=rec.visit_id,
+                    recommendation_root=True,
+                    source__root__service=random.choice(rec.services),
+                )
+                ua = UserActionFactory(
+                    **self.user_params, order=True, source__visit_id=ua.target.visit_id
+                )
+
+            else:
+                ua = UserActionFactory(
+                    **self.user_params, order=True, source__visit_id=self.last_visit_id
+                )
+        else:
+            ua = UserActionFactory(
+                **self.user_params,
+                order=True,
+                source__visit_id=start_ua.target.visit_id,
+            )
+        self.last_visit_id = ua.target.visit_id
+
+        return ua
+
+    def _get_last_rec(self):
+        return Recommendation.objects(**self.user_params).order_by("-timestamp").first()
+
+    def _get_last_user_action(self):
+        return UserAction.objects(**self.user_params).order_by("-timestamp").first()
+
+
+def the_testing_db_context(func):
+    def func_with_testing_db_context(*args, **kwargs):
+        uri = TestingConfig.MONGODB_HOST
+        db = connect(host=uri)
+
+        func(*args, **kwargs)
+
+        db_name = uri_parser.parse_uri(uri)["database"]
+        db.drop_database(db_name)
+        disconnect()
+
+    return func_with_testing_db_context
+
+
+class UserJourney:
+    def __init__(self, anonymous=False, user=None, unique_id=None, panel_id="v1"):
+        self.lluj = LowLevelUserJourney(
+            anonymous=anonymous, user=user, unique_id=unique_id, panel_id=panel_id
+        )
+
+    def next(self, n: int = 1) -> "UserJourney":
+        new_stage = deepcopy(self)
+        new_stage.lluj.uas_chain(n=n)
+        return new_stage
+
+    def order(self):
+        new_stage = deepcopy(self)
+        new_stage.lluj.order()
+        return new_stage
+
+    def go_to_panel(self):
+        new_stage = deepcopy(self)
+        new_stage.lluj.go_to_rec_page()
+        return new_stage
+
+    def service(self, k: int = None):
+        new_stage = deepcopy(self)
+        recommendation = Recommendation.objects(
+            visit_id=new_stage.lluj.last_visit_id
+        ).first()
+        if recommendation is None:
+            raise Exception(
+                "User is not on the recommendation panel. To choose a service"
+                " user has to be on the recommendation panel. Use .go_to_panel"
+                " function"
+            )
+        if k is None:
+            new_stage.lluj.click_random_service_from_rec(recommendation)
+        else:
+            new_stage.lluj.click_service_from_rec(k, recommendation)
+        return new_stage


### PR DESCRIPTION
Fix #282 

### What has been done

There is a new function `regenerate_sarses` that is now a new entry point to the SARSes (re)generation. Internally it uses old generate_sarses function but enhanced.

`regenerate_sarses` function works in the every case:

- when there are missing data in the DB (users, services, user actions, recommendations, etc.)
- when there are doubled user actions (common case in the production data)
- when the DB is empty
- when there are old SARSes in the DB, generated by the old `generate_sarses` function:
    - in this case, all old SARSes are regenerated. It doesn't regenerate sarses generated by itself, so you can run it multiple times and it will not unnecessarily repeat the same work.
- when the new user actions or recommendations are streamed into the recommender DB (in addition to the old ones). It generate new SARSes based on new data and regenerate old SARSes but only if they are affected by the new data. In every other case it doesn't regenerate SARSes so it will not unnecessarily repeat the same work.

Due to these advantages there is no need to have migration that adjust old SARSes. If you run regenerate_sarses with the e.g. production DB with old data, everything will be appropriately regenerated - what will take a significant amount of time, but every next call to the `regenerate_sarses` will only incorporate new data from the DB in the incremental fashion, so it's optimal.

Additionally, there are following improvements:

- multiprocessing in SARSes (re)generation is supported
- there are progress bars and helpful log statements
- there is flask db regenerate_sarses (with default `multiprocessing=True` and `verbose=True`)
- indexes in the DB models for faster operations

### Tests

In order to be able to implement the above functionalities, it was necessary to heavily improve tests:
- multiprocessing is now supported in the tested code and in tests themesleves (they can run in parallel)
- `regenerate_sarses` need exhaustive tests so there are new modules UserJourney and LowLevelUserJourney that allow for very easy and efficient modelling variety of user journeys (they generates all data reflecting user journey in the DB, like: user actions, recommendations, users, services, etc.)
- All `regenerate_sarses` tests are performed for all combinations of: anonymous/logged users, panel_ids and multiprocessing on/off.
- there is also a tool for visualizing user journey in the MP as graphs: `visualize_uas` function.
- pytest-randomly - helpful library that seeds random generators with set seed during tests so they are "deterministically random", moreover it shuffle tests what reduces risk of surprising inter-test dependencies (more info [here](https://pypi.org/project/pytest-randomly/)).

### TODO in other PR(s)

- beter code coverage, even more `regenerate_sarses` tests
- UserJourne and LowLevelUserJourney refactoring
- progress bars for parallel `regenerate sarses` (now progress bars work only in sequential version)
- full `regenerate sarses` parallelization. For now `generate_sarses` function is fully parallel but `regenerate_sarses` function uses `get_recs_for_update` function internally where is a room for improvements in parallelization.
- tests themselves now run in parallel but there is no overall time improvement probably due to mongoengine connection aliases - it has to be investigated.
- demon that schedules `regenerate_sarses` calls. It could launch regeneration based on following conditions:
    - new, unprocessed user actions number limit exceeded.
    - new, unprocessed recommendations number limit exceeded.
    - cyclic launching based on time.
    - on demand (e.g. via its own endpoint)

