### PR TITLE
[#312] Changes in the deletion of past SARS in the RL data extraction step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-MM-DD
 ### Added
 - User actions documentation [@JanKapala, @Michal-Kolomanski]
+- Logging in generation of SARSes [@Michal-Kolomanski]
 ### Changed
+- Limited SARSes deletion in the RL data extraction step [@Michal-Kolomanski]
 ### Fixed
 - Details in the AE data preparation step [@Michal-Kolomanski]
 ### Removed

--- a/recommender/commands/db.py
+++ b/recommender/commands/db.py
@@ -21,6 +21,9 @@ from tests.factories.marketplace.faker_seeds.utils.dumpers import (
     dump_taglines,
 )
 from tests.factories.populate_database import populate_users_and_services
+from logger_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def _seed():
@@ -72,9 +75,9 @@ def _seed_faker():
 def _regenerate_sarses():
     """Regenerate SARSes"""
 
-    print("Regenerating SARSes...")
+    logger.info("Regenerating SARSes...")
     regenerate_sarses(multi_processing=True, verbose=True)
-    print("SARSes regenerated successfully!")
+    logger.info("SARSes regenerated successfully!")
 
 
 def db_command(task):

--- a/recommender/engines/rl/ml_components/services_history_generator.py
+++ b/recommender/engines/rl/ml_components/services_history_generator.py
@@ -82,11 +82,11 @@ def _list_difference(minuend: List[Any], subtrahend: List[Any]) -> List[Any]:
 def concat_histories(accessed_services, root_uas):
     """
     This function get user's accessed services (from the DB dump) and combine
-     it with clicked services that correspond to root user actions.
+    it with clicked services that correspond to root user actions.
 
     Essentially it appends accessed services on the beginning of the list of
-     services from root user actions but it filter ordered services
-     duplicates out of it.
+    services from root user actions, but it filters ordered services
+    duplicates out of it.
 
     Args:
         accessed_services: User's accessed services (from DB dump)

--- a/recommender/engines/rl/ml_components/synthetic_dataset/dataset.py
+++ b/recommender/engines/rl/ml_components/synthetic_dataset/dataset.py
@@ -193,7 +193,7 @@ def generate_synthetic_sarses(
     interactions_range: Tuple[int, int] = (3, 10),
     reward_generation_mode: RewardGeneration = RewardGeneration.COMPLEX,
     simple_reward_threshold: int = 0.5,
-) -> Tuple[List[Sars]]:
+) -> List[Sars]:
     """
     Generates artificial SARS dataset that will be used for training
     and benchmarking the RL agent.


### PR DESCRIPTION
Fixes #312

Changes:
- No deletion of "old" SARSes which had the same K at the beginning of the RL data extraction step,
- Logging,
- Multiprocessing=False,
- Verbose=True - I think its better default behaviour,
- Tidying up the code.

Expected output from the training:
`mongoengine.errors.DoesNotExist: Trying to dereference unknown document DBRef('user', -1)`
Related to: https://github.com/cyfronet-fid/recommender-system/issues/317
