### PR TITLE
[#317] Fix: trying to dereference unknown ID of a user (-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - User actions documentation [@JanKapala, @Michal-Kolomanski]
 - Logging in generation of SARSes [@Michal-Kolomanski]
+- SARS generator - saving users with ID -1 to the database while they are not logged in [@Michal-Kolomanski]
 ### Changed
 - Limited SARSes deletion in the RL data extraction step [@Michal-Kolomanski]
 ### Fixed
 - Details in the AE data preparation step [@Michal-Kolomanski]
 ### Removed
-
+- Invalid user actions progress bar [@Michal-Kolomanski]
 ## [3.1.0] - 2022-01-17
 ### Added
 - Add the AI docs, describing the training, data and algorithm evaluation [@wujuu, @JanKapala, @Michal-Kolomanski]

--- a/recommender/engines/rl/training/data_extraction_step/data_extraction_step.py
+++ b/recommender/engines/rl/training/data_extraction_step/data_extraction_step.py
@@ -46,7 +46,7 @@ class RLDataExtractionStep(DataExtractionStep):
         start = time()
         sarses = self._generate_sarses()
         end = time()
-        return sarses, {"sarses_generation_duration": f"{end - start}s"}
+        return sarses, {"sarses_generation_duration": f"{round(end - start, 2)}s"}
 
     def _need_to_generate_sarses(self) -> bool:
         """Is there a need to generate synthetic sarses?"""


### PR DESCRIPTION
fixes #317 

Changes:
- When there is no associated user with a specific recommendation, a user with ID = -1 is saved to the database. This user is used for every recommendation without an associated user. Unfortunately, most of our recommendations do not have associated user so thanks to saving, the process is a little bit faster and resolves the mentioned bug.
- The progress bar which was not working is removed. 
