### PR TITLE
[#334] Bug fix: InsufficientRecommendationSpace in RL model evaluation step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Black version = 20.8b0 - click dependency [@Michal-Kolomanski]
 ### Fixed
+- InsufficientRecommendationSpace in RL model evaluation step [@Michal-Kolomanski]
 ### Removed
+- RL v2 training in flask train all [@Michal-Kolomanski]
 
 ## [3.1.1] - 2022-01-31
 ### Added

--- a/recommender/api/endpoints/recommendations.py
+++ b/recommender/api/endpoints/recommendations.py
@@ -16,7 +16,7 @@ from recommender.engines.ncf.inference.ncf_inference_component import (
 from recommender.engines.panel_id_to_services_number_mapping import PANEL_ID_TO_K
 from recommender.engines.rl.inference.rl_inference_component import RLInferenceComponent
 from recommender.errors import (
-    InsufficientRecommendationSpace,
+    InsufficientRecommendationSpaceError,
     InvalidRecommendationPanelIDError,
 )
 from recommender.api.schemas.recommendation import (
@@ -106,8 +106,8 @@ class Recommendation(Resource):
             Deserializer.deserialize_recommendation(json_dict_with_services).save()
 
             response = {"recommendations": services_ids}
-        except InsufficientRecommendationSpace:
-            logger.error(InsufficientRecommendationSpace().message())
+        except InsufficientRecommendationSpaceError:
+            logger.error(InsufficientRecommendationSpaceError().message())
             response = {"recommendations": []}
 
         return response

--- a/recommender/commands/train.py
+++ b/recommender/commands/train.py
@@ -47,7 +47,6 @@ def _all():
     EmbeddingComponent()()
     NCFPipeline(NCF_PIPELINE_CONFIG)()
     RLPipeline(RL_PIPELINE_CONFIG_V1)()
-    RLPipeline(RL_PIPELINE_CONFIG_V2)()
 
 
 def train_command(task):

--- a/recommender/engines/base/base_inference_component.py
+++ b/recommender/engines/base/base_inference_component.py
@@ -9,7 +9,7 @@ from typing import Dict, Any, List
 
 from recommender.engines.panel_id_to_services_number_mapping import PANEL_ID_TO_K
 from recommender.errors import (
-    InsufficientRecommendationSpace,
+    InsufficientRecommendationSpaceError,
     InvalidRecommendationPanelIDError,
 )
 from recommender.models import User, SearchData
@@ -117,7 +117,7 @@ class BaseInferenceComponent(ABC):
 
         candidate_services = list(retrieve_services_for_recommendation(search_data))
         if len(candidate_services) < self.K:
-            raise InsufficientRecommendationSpace()
+            raise InsufficientRecommendationSpaceError()
         recommended_services = random.sample(list(candidate_services), self.K)
         recommended_services_ids = [s.id for s in recommended_services]
 

--- a/recommender/engines/ncf/inference/ncf_inference_component.py
+++ b/recommender/engines/ncf/inference/ncf_inference_component.py
@@ -13,7 +13,7 @@ from recommender.engines.ncf.ml_components.neural_collaborative_filtering import
     NEURAL_CF,
 )
 from recommender.errors import (
-    InsufficientRecommendationSpace,
+    InsufficientRecommendationSpaceError,
     NoPrecalculatedTensorsError,
 )
 from recommender.models import User, SearchData
@@ -89,7 +89,7 @@ class NCFInferenceComponent(BaseInferenceComponent):
             retrieve_services_for_recommendation(search_data, user.accessed_services)
         )
         if len(candidate_services) < self.K:
-            raise InsufficientRecommendationSpace()
+            raise InsufficientRecommendationSpaceError()
         candidate_services_ids = [s.id for s in candidate_services]
 
         (

--- a/recommender/engines/rl/ml_components/search_data_encoder.py
+++ b/recommender/engines/rl/ml_components/search_data_encoder.py
@@ -12,6 +12,7 @@ from recommender.services.fts import retrieve_forbidden_services, filter_service
 from recommender.engines.rl.ml_components.services_history_generator import (
     get_ordered_services,
 )
+from recommender.errors import SizeOfUsersAndSearchDataError
 
 
 class SearchDataEncoder:
@@ -30,8 +31,9 @@ class SearchDataEncoder:
     def __call__(
         self, users: List[User], search_data: List[SearchData]
     ) -> torch.Tensor:
+        if not len(users) == len(search_data):
+            raise SizeOfUsersAndSearchDataError()
 
-        assert len(users) == len(search_data)
         batch_size = len(users)
 
         mask = torch.zeros(batch_size, self.I)
@@ -43,6 +45,7 @@ class SearchDataEncoder:
             filtered_service_indices = get_service_indices(
                 self.index_id_map, filtered_services.distinct("id")
             )
+
             ordered_service_indices = get_service_indices(
                 self.index_id_map, [s.id for s in ordered_services]
             )

--- a/recommender/engines/rl/ml_components/service_selector.py
+++ b/recommender/engines/rl/ml_components/service_selector.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 
 from recommender.engines.autoencoders.ml_components.embedder import Embedder
-from recommender.errors import InsufficientRecommendationSpace
+from recommender.errors import InsufficientRecommendationSpaceError
 from recommender.models import Service
 from logger_config import get_logger
 
@@ -59,7 +59,7 @@ class ServiceSelector:
         K = weights.shape[0]
 
         if (mask > 0).sum() < K:
-            raise InsufficientRecommendationSpace()
+            raise InsufficientRecommendationSpaceError()
 
         engagement_values = F.softmax(weights @ self.itemspace.T, dim=1)
 

--- a/recommender/engines/rl/ml_components/synthetic_dataset/dataset.py
+++ b/recommender/engines/rl/ml_components/synthetic_dataset/dataset.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member, invalid-name, missing-module-docstring, too-many-locals, too-many-arguments
+# pylint: disable=no-member, invalid-name, missing-module-docstring, too-many-locals, too-many-arguments, line-too-long
 import random
 from typing import List, Dict, Tuple
 
@@ -197,7 +197,7 @@ def generate_synthetic_sarses(
     """
     Generates artificial SARS dataset that will be used for training
     and benchmarking the RL agent.
-    It generates users belonging to a predefined category and scientific domain clusters
+    It generates users who belong to a predefined category and scientific domain clusters
     and for each one generates specified number of SARSes by:
         - choosing an action randomly (LIRD is a off-policy RL algorithm)
         - approximating heuristically the engagement of a user in a given service

--- a/recommender/errors.py
+++ b/recommender/errors.py
@@ -46,7 +46,7 @@ class MissingComponentError(RecommendationEngineError):
     pass
 
 
-class InsufficientRecommendationSpace(RecommendationEngineError):
+class InsufficientRecommendationSpaceError(RecommendationEngineError):
     def message(self):  # pragma: no cover
         return (
             "The required number of services to recommend exceed the"
@@ -168,3 +168,8 @@ class RangeOfCommonServicesError(Exception):
         return (
             "Invalid range of common services. The minimum cannot exceed the maximum."
         )
+
+
+class SizeOfUsersAndSearchDataError(Exception):
+    def message(self):
+        return "Length of users and search data is not equal"

--- a/tests/engine/test_service_selector.py
+++ b/tests/engine/test_service_selector.py
@@ -6,7 +6,7 @@ import torch
 from recommender.engines.autoencoders.ml_components.autoencoder import AutoEncoder
 from recommender.engines.autoencoders.ml_components.embedder import Embedder
 from recommender.engines.rl.ml_components.service_selector import ServiceSelector
-from recommender.errors import InsufficientRecommendationSpace
+from recommender.errors import InsufficientRecommendationSpaceError
 from tests.factories.marketplace import ServiceFactory
 
 
@@ -120,6 +120,6 @@ def test_raise_insufficient_recommendation_space(
     service_embedder = Embedder(AutoEncoder(FEATURES_DIM, SE))
     service_selector = ServiceSelector(service_embedder)
 
-    with pytest.raises(InsufficientRecommendationSpace):
+    with pytest.raises(InsufficientRecommendationSpaceError):
         service_selector(weights, mask=torch.zeros(len(services)))
         service_selector(weights, mask=torch.Tensor([0, 0, 0, 1]))


### PR DESCRIPTION
closes #334 

This error applies only to the evaluation step model, i.e. the step in which we check whether the newly trained model would cope better during situations in which the old model gave recommendations. So we recreate the context of the old recommendations and check how well the new model handles the recommendations in these contexts.

The reason behind the bug, situation:
A user made such a query that there are only 3 available services. The user got a recommendation panel with 3 recommendations. Let us assume that the user ordered one of those 3 recommended services. In the process of the RL pipeline, we were able to generate SARS, give a proper reward for the RS system, and successfully train the model. But in the context of the model evaluation step, we are no longer able to reconstruct such a recommendation panel because we have only 2 services instead of 3. Why? Because in the process of creating a context of recommendations for the user (among others) we reject all ordered services by him. So information about ordering service by the user which was influenced by the presented recommendations is lost in this step. When our RS system has a recommendation context with less than 3 services available, it raises InsufficientRecommendationSpaceError. Our RL pipeline was not ready for such a situation and it terminated the training.

Changes:
- RL v2 training is no longer triggered by the command: `flask train all`,
- SARS may be invalid due to the InsufficientRecommendationSpace, from now we are catching this exception and skipping invalid sarses,
- Metric: how many invalid SARSes there were and also their proportion `invalid_sarses/sarses` is calculated.
It looks like this:
![image](https://user-images.githubusercontent.com/47147210/153892241-46310d50-e995-40ac-be9e-f47857af8109.png)
Using the latest production data there are 9624 SARSes in total but 11 of them are invalid.

NOTE:
1) This PR was successfully trained on the latest production data - which previously raised  InsufficientRecommendationSpaceError,
2) Logger with the message:  SARS with ID 6204f610754c19f455d44217 is invalid due to error 'The required number of services to recommend exceed the matching services space size.' is set here to info level but in code its set to debug level as it is better behaviour by default. 