### PR TITLE
[#349] search_data migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD
 ### Added
+- search_data migration [@Michal-Kolomanski]
 ### Changed
 - engine_version field in recommendation request is required [@Michal-Kolomanski]
 - Structure of the tests in the tests folder [@Michal-Kolomanski]

--- a/recommender/migrate/migrations/20220315122123_searchdata_to_elastic_services.py
+++ b/recommender/migrate/migrations/20220315122123_searchdata_to_elastic_services.py
@@ -1,0 +1,86 @@
+# pylint: disable=invalid-name, missing-module-docstring, line-too-long
+
+from copy import deepcopy
+from mongoengine import QuerySet
+from tqdm import tqdm
+from recommender.services.fts import filter_services
+from recommender.models.search_data import SearchData
+from recommender.migrate.base_migration import BaseMigration
+from logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class SearchDataToElasticServices(BaseMigration):
+    """If recommendation and state documents do not have elastic_services, create it using searchdata"""
+
+    def up(self):
+        (
+            recs_for_up,
+            len_recs,
+            states_for_up,
+            len_states,
+        ) = self.get_update_candidates()
+
+        if len_recs:
+            logger.info("Found %s recommendations documents to update", len_recs)
+
+            for rec in tqdm(list(recs_for_up), desc="Recommendations to update"):
+                elastic_services = self.get_elastic_services_from_sd(rec["search_data"])
+
+                self.pymongo_db.recommendation.update_one(
+                    {"_id": {"$eq": rec["_id"]}},
+                    {"$set": {"elastic_services": elastic_services.distinct("id")}},
+                )
+
+        if len_states:
+            logger.info("Found %s states documents to update", len_states)
+
+            for state in tqdm(list(states_for_up), desc="States to update"):
+                elastic_services = self.get_elastic_services_from_sd(
+                    state["search_data"]
+                )
+
+                self.pymongo_db.state.update_one(
+                    {"_id": {"$eq": state["_id"]}},
+                    {"$set": {"elastic_services": elastic_services.distinct("id")}},
+                )
+
+    def down(self):
+        # Information about which documents didn't have elastic_services before migration took place is lost
+        pass
+
+    def get_update_candidates(self):
+        """Get candidates for update"""
+
+        recs_for_up = self.pymongo_db.recommendation.find(
+            {"elastic_services": {"$exists": False}}
+        )
+
+        states_for_up = self.pymongo_db.state.find(
+            {"elastic_services": {"$exists": False}}
+        )
+
+        len_recs = len(list(deepcopy(recs_for_up)))
+        len_states = len(list(deepcopy(states_for_up)))
+
+        return recs_for_up, len_recs, states_for_up, len_states
+
+    def get_elastic_services_from_sd(self, search_data: SearchData) -> QuerySet:
+        """Get elastic_services from search_data"""
+        search_data_dict = self.pymongo_db.search_data.find_one({"_id": search_data})
+
+        sd = SearchData(
+            categories=search_data_dict["categories"],
+            geographical_availabilities=search_data_dict["geographical_availabilities"],
+            providers=search_data_dict["providers"],
+            related_platforms=search_data_dict["related_platforms"],
+            scientific_domains=search_data_dict["scientific_domains"],
+            target_users=search_data_dict["target_users"],
+            q=search_data_dict.get(
+                "q", ""
+            ),  # Synthetic search_data does not have 'q' set
+        )
+
+        elastic_services = filter_services(sd)
+        return elastic_services


### PR DESCRIPTION
closes #349 

Migration aim:
- Add elastic_services to recommendation and state documents

Successfully tested on the fresh production recommender database.

There are more than 200 000 documents in the recommendation collection. Each document has a filed **_services_** which stands for the IDs of recommended services. In general, the assumption is that the IDs from the **_services_** should be contained in the IDs from the **_elastic_services_** field. After the migration, it turned out that for **3250** documents at least one ID of recommended service from **_services_** is no longer in the range of **_elastic_services_**. 

Why? Exactly the same query for services (and recommendations) made six months ago could give slightly different results than the execution of such a query now. It is enough for the service to change its category, scientific domain, geographical availabilities, etc., and a recommendation already made in a given context may turn out to be not valid anymore.

List of services that must have been changed in some way in the past: 
`['B2DROP', 'B2FIND', 'B2HANDLE', 'B2NOTE', 'B2SAFE', 'B2SHARE', 'B2ACCESS', 'PROMINENCE', 'Greek Sustainable Development Solutions Network (SDSN) OpenAIRE Community Gateway', 'OpenAIRE Research Graph', 'European Marine Science OpenAIRE Community Gateway', 'SeaDataNet DOI minting service', 'GÉANT IP', 'Digital Humanities and Cultural Heritage OpenAIRE Community Gateway', 'InAcademia', 'Accounting Framework', 'Access to Open Data platforms', 'PRISM: Peer Review Information Service for Monographs', 'OpenAIRE Research Community Dashboard (CONNECT)', 'ISIDORE', 'TOPOS Observatory for Organisations', 'CLOUDIFIN', 'ENES Data Space']`
 
A case that has been thoroughly investigated using the Marketplace's logs: **_'TOPOS Observatory for Organisations'_** with `ID=506` and recommendation request with ID=`611d02d74a8488190dafaacd`.
Recommendation context:
- services: `[86, 372, 506]`
- elastic_services: `[90, 96, 221, 372, 408, 417, 419, 420, 421, 422, 423, 424, 425, 436, 491, 499, 523, 561, 620, 621, 663, 671, 672, 673]`
- overlap: only `[372]`
- timestamp `datetime.datetime(2021, 8, 18, 12, 53, 43, 698000)`
- context (search_data) : `{'_id': ObjectId('611d02d74a8488190dafaacc'), 'q': '', 'categories': [17, 31, 48, 49, 166, 184], 'geographical_availabilities': [], 'providers': [], 'related_platforms': [], 'scientific_domains': [], 'target_users': []} `
- category with `ID=17` is **_software_**. The rest of IDs are the subcategories of the software category.

**_'TOPOS Observatory for Organisations'_** context from logs:
1) 'TOPOS Observatory for Organisations' - was created on **22/06/2021** with **sharing_and_discovery-software** category
2) **07/03/2022** the category was changed to: **sharing_and_discovery-scholarly_communication**

Results:
- After a very in-depth analysis, it turned out that the category on this service has been changed and that is why we can no longer get this service in the **software** category. 
- We have every right to assume, with a high degree of certainty, that the other cases are the same,
- The migration code appears to works just fine. The differences are due to the features of our portal.