### PR TITLE
[#370] Create a separate random engine for serving recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD
 ### Added
+- Random recommendations' engine for anonymous users [@Michal-Kolomanski]
 ### Changed
 - Cleaning up the main conftest [@Michal-Kolomanski]
 - More metadata in autoencoders pipeline [@Michal-Kolomanski]

--- a/README.md
+++ b/README.md
@@ -120,9 +120,24 @@ pipenv run pytest ./tests
 docker-compose -f docker-compose.testing.yml up && docker-compose -f docker-compose.testing.yml down
 ```
 
+### Recommendation Engines
+Recommendation engines ensure that both logged in and non-logged in users receive relevant recommendations.
+
+#### Engines for logged-in users (training required):
+- [NCF](#training)
+- [RL](#training)
+
+These engines use artificial intelligence algorithms to make recommendations based on a user's interests, the context of the search, and all of that user's and other users' behaviours on the portal.
+
+#### Engines for anonymous users (no training required):
+- Anonymous (in development) - integrated with Google Analytics
+- Random
+
+These engines employ statistical methods to provide an anonymous user with the best possible recommendations. The anonymous engine provides information, for example, which services are most commonly visited or purchased by other users in a specific search context. In that case, even if a user is anonymous, our recommender system can provide the user with valuable recommendations.
+
 ### Training
 
-Recommender system can use one of two recommendation engines implemented:
+Recommender system can use one of two recommendation engines implemented for logged-in user:
 - `NCF` - based on [Neural Collaborative Filtering](https://arxiv.org/abs/1708.05031) paper.
 - `RL` - based on [Deep Deterministic Policy Gradient](https://arxiv.org/abs/1509.02971) paper.
 
@@ -141,7 +156,7 @@ GPU support can be enabled using an environmental variable `TRAINING_DEVICE` (lo
 
 After training is finished, the system is immediately ready for serving recommendations (no manual reloading is needed).
 
-To specify from which engine the recommendations are requested, provide an optional `engine_version` parameter inside the body of `\recommendations` endpoint. `NCF` denotes the NCF engine, while `RL` indicates the RL engine.
+To specify from which engine the recommendations are requested, provide a `engine_version` parameter inside the body of `\recommendations` endpoint. `NCF` denotes the NCF engine, while `RL` indicates the RL engine.
 It is possible to define which algorithm should be used by default in the absence of the `engine_version` parameter by modifying the `DEFAULT_RECOMMENDATION_ALG` parameter from .env file
 (look into [ENV variables](#env-variables) section).
 
@@ -206,7 +221,7 @@ present in the project root directory. Details:
 - `SENTRY_ENVIRONMENT` - environment name - it's optional and it can be a free-form string. If not specified and using Docker, it is set to `development`/`testing`/`production` respectively to the docker environment.
 - `SENTRY_RELEASE` - human-readable release name - it's optional and it can be a free-form string. If not specified, Sentry automatically set it based on the commit revision number.
 - `TRAINING_DEVICE` - the device used for training of neural networks: `cuda` for GPU support or `cpu` (note: `cuda` support is experimental and works only in Jupyter notebook `neural_cf` - not in the recommender dev/prod/test environment)
-- `DEFAULT_RECOMMENDATION_ALG` - the version of the recommender engine (one of `NCF`, `RL`) - Whenever request handling or celery task need this variable, it is dynamically loaded from the .env file, so you can change it during flask server runtime.
+- `DEFAULT_RECOMMENDATION_ALG` - the version of the recommender engine (one of `NCF`, `RL`, `random`) - Whenever request handling or celery task need this variable, it is dynamically loaded from the .env file, so you can change it during flask server runtime.
 - `RS_SUBSCRIBER_HOST` - the address of your JMS provider (optional)
 - `RS_SUBSCRIBER_PORT` - the port of your JMS provider (optional)
 - `RS_SUBSCRIBER_USERNAME` - your login to the JMS provider (optional)

--- a/recommender/api/endpoints/recommendations.py
+++ b/recommender/api/endpoints/recommendations.py
@@ -12,7 +12,7 @@ from recommender.api.schemas.recommendation import (
     recommendation_context,
 )
 from recommender.services.deserializer import deserialize_recommendation
-from recommender.services.rec_engine_selector import load_engine
+from recommender.services.engine_selector import load_engine
 from logger_config import get_logger
 
 api = Namespace("recommendations", "Endpoint used for getting recommendations")

--- a/recommender/engines/engines.py
+++ b/recommender/engines/engines.py
@@ -1,0 +1,15 @@
+"""All available engines to serve recommendations for /recommendation endpoint"""
+from recommender.engines.ncf.inference.ncf_inference_component import (
+    NCFInferenceComponent,
+)
+from recommender.engines.rl.inference.rl_inference_component import RLInferenceComponent
+from recommender.engines.random.inference.random_inference_component import (
+    RandomInferenceComponent,
+)
+
+# Order of engines may have an impact depending on the given context
+ENGINES = {
+    RLInferenceComponent.engine_name: RLInferenceComponent,
+    NCFInferenceComponent.engine_name: NCFInferenceComponent,
+    RandomInferenceComponent.engine_name: RandomInferenceComponent,
+}

--- a/recommender/engines/ncf/inference/ncf_inference_component.py
+++ b/recommender/engines/ncf/inference/ncf_inference_component.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 
 import torch
 
-from recommender.engines.base.base_inference_component import BaseInferenceComponent
+from recommender.engines.base.base_inference_component import MLEngineInferenceComponent
 from recommender.engines.ncf.ml_components.neural_collaborative_filtering import (
     NeuralCollaborativeFilteringModel,
     NEURAL_CF,
@@ -23,8 +23,12 @@ from logger_config import get_logger
 logger = get_logger(__name__)
 
 
-class NCFInferenceComponent(BaseInferenceComponent):
-    """Neural Collaborative Filtering Inference Component"""
+class NCFInferenceComponent(MLEngineInferenceComponent):
+    """
+    Recommender engine that provides logged-in users with personalized recommendations in a given context.
+    """
+
+    engine_name = "NCF"
 
     def __init__(self, K: int) -> None:
         self.neural_cf_model = None
@@ -73,7 +77,7 @@ class NCFInferenceComponent(BaseInferenceComponent):
 
         return users_ids, users_tensor, services_ids, services_tensor
 
-    def _for_logged_user(
+    def _generate_recommendations(
         self, user: User, elastic_services: Tuple[int], search_data: SearchData
     ) -> List[int]:
         """Generate recommendation for logged user.

--- a/recommender/engines/random/inference/random_inference_component.py
+++ b/recommender/engines/random/inference/random_inference_component.py
@@ -1,0 +1,53 @@
+# pylint: disable=invalid-name, too-few-public-methods, line-too-long
+"""Recommender engine that provides users with random recommendations in a given context"""
+
+import random
+from typing import List, Tuple, Dict, Any
+
+from recommender.engines.base.base_inference_component import BaseInferenceComponent
+from recommender.services.fts import retrieve_services_for_recommendation
+
+
+class RandomInferenceComponent(BaseInferenceComponent):
+    """
+    Recommender engine that provides all users with random recommendations in a given context.
+
+    Used for:
+        - random users,
+        - all users if necessary (for example during ML training).
+    """
+
+    engine_name = "random"
+
+    def __call__(self, context: Dict[str, Any]) -> List[int]:
+        """
+        Get random recommendations in a given context.
+
+        Args:
+            context: json dict from the /recommendations endpoint request.
+
+        Returns:
+            Tuple of recommended services ids.
+        """
+        elastic_services, _ = self._get_recommendation_context(context)
+
+        return self._generate_recommendations(elastic_services)
+
+    def _generate_recommendations(self, elastic_services: Tuple[int]) -> List[int]:
+        """
+        Generate recommendations.
+
+        Args:
+            elastic_services: item space from the Marketplace.
+
+        Returns:
+            recommended_services_ids: List of recommended services ids.
+        """
+        candidate_services = list(
+            retrieve_services_for_recommendation(elastic_services)
+        )
+
+        recommended_services = random.sample(list(candidate_services), self.K)
+        recommended_services_ids = [s.id for s in recommended_services]
+
+        return recommended_services_ids

--- a/recommender/engines/rl/inference/rl_inference_component.py
+++ b/recommender/engines/rl/inference/rl_inference_component.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-module-docstring, missing-class-docstring, too-few-public-methods
-# pylint: disable=too-many-instance-attributes, no-self-use
+# pylint: disable=too-many-instance-attributes, no-self-use, line-too-long
 
 from typing import Tuple
 
@@ -12,20 +12,30 @@ from recommender.engines.autoencoders.ml_components.embedder import (
 )
 from recommender.engines.panel_id_to_services_number_mapping import K_TO_PANEL_ID
 from recommender.engines.rl.utils import create_state
-from recommender.engines.base.base_inference_component import BaseInferenceComponent
+from recommender.engines.base.base_inference_component import MLEngineInferenceComponent
 from recommender.engines.rl.ml_components.actor import Actor
 from recommender.engines.rl.ml_components.state_encoder import StateEncoder
 from recommender.engines.rl.ml_components.service_selector import ServiceSelector
 from recommender.models import User, SearchData
 
 
-class RLInferenceComponent(BaseInferenceComponent):
+class RLInferenceComponent(MLEngineInferenceComponent):
+    """
+    Recommender engine that provides logged-in users with personalized recommendations in a given context.
+    """
+
+    engine_name = "RL"
+
     def __init__(self, K: int, exploration: bool = False, act_noise: float = 0.0):
         self.exploration = exploration
         self.act_noise = act_noise
         super().__init__(K)
 
     def _load_models(self) -> None:
+        """It loads model or models needed for recommendations and raise
+        exception if it is not available in the database.
+        """
+
         version = K_TO_PANEL_ID.get(self.K)
         self.actor = Actor.load(version=version)
         self.actor.eval()
@@ -37,9 +47,21 @@ class RLInferenceComponent(BaseInferenceComponent):
         )
         self.service_selector = ServiceSelector(self.service_embedder)
 
-    def _for_logged_user(
+    def _generate_recommendations(
         self, user: User, elastic_services: Tuple[int], search_data: SearchData
     ) -> Tuple[int]:
+        """Generate recommendation for logged user.
+
+        Args:
+            user: user for whom recommendation will be generated.
+            elastic_services: item space from the Marketplace.
+            search_data: search phrase and filters information for narrowing
+             down an item space.
+
+        Returns:
+            service_ids: List of recommended services ids.
+        """
+
         state = create_state(user, elastic_services, search_data)
         state_tensors = self.state_encoder([state])
         weights_tensor = self._get_weights(state_tensors)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from random import seed, randint
 
 import pytest
 import mongoengine
+import torch
+from mongoengine import disconnect, connect
 from mongoengine import disconnect, connect
 from pymongo import uri_parser
 
@@ -27,6 +29,7 @@ from tests.engines.rl.conftest import (
     rl_pipeline_v2_config,
     base_rl_pipeline_config,
 )
+from tests.endpoints.conftest import recommendation_data
 
 
 @pytest.fixture()

--- a/tests/endpoints/conftest.py
+++ b/tests/endpoints/conftest.py
@@ -1,3 +1,4 @@
+# pylint: disable-all
 """Fixtures for endpoints testing"""
 import pytest
 
@@ -82,4 +83,30 @@ def mp_dump_data():
             {"id": 1, "name": "lcs1", "description": "desc"},
             {"id": 2, "name": "lcs2", "description": "desc"},
         ],
+    }
+
+
+@pytest.fixture
+def recommendation_data():
+    return {
+        "user_id": 1,
+        "unique_id": "5642c351-80fe-44cf-b606-304f2f338122",
+        "timestamp": "2021-03-18T18:49:55.006Z",
+        "visit_id": "202090a4-de4c-4230-acba-6e2931d9e37c",
+        "page_id": "some_page_identifier",
+        "panel_id": "v1",
+        "engine_version": "NCF",
+        "elastic_services": [1, 2, 3],
+        "search_data": {
+            "q": "Cloud GPU",
+            "categories": [1],
+            "geographical_availabilities": ["PL"],
+            "order_type": "open_access",
+            "providers": [1],
+            "rating": "5",
+            "related_platforms": [1],
+            "scientific_domains": [1],
+            "sort": "_score",
+            "target_users": [1],
+        },
     }

--- a/tests/endpoints/test_recommendations.py
+++ b/tests/endpoints/test_recommendations.py
@@ -3,41 +3,13 @@
 import json
 from copy import deepcopy
 
-from pytest import fixture
-
-
-@fixture
-def recommendation_data():
-    return {
-        "user_id": 1,
-        "unique_id": "5642c351-80fe-44cf-b606-304f2f338122",
-        "timestamp": "2021-03-18T18:49:55.006Z",
-        "visit_id": "202090a4-de4c-4230-acba-6e2931d9e37c",
-        "page_id": "some_page_identifier",
-        "panel_id": "v1",
-        "engine_version": "NCF",
-        "elastic_services": [1, 2, 3],
-        "search_data": {
-            "q": "Cloud GPU",
-            "categories": [1],
-            "geographical_availabilities": ["PL"],
-            "order_type": "open_access",
-            "providers": [1],
-            "rating": "5",
-            "related_platforms": [1],
-            "scientific_domains": [1],
-            "sort": "_score",
-            "target_users": [1],
-        },
-    }
-
 
 def test_recommendations(client, mocker, recommendation_data):
     _inference_component_init_mock = mocker.patch(
-        "recommender.engines.base.base_inference_component.BaseInferenceComponent.__init__"
+        "recommender.engines.base.base_inference_component.MLEngineInferenceComponent.__init__"
     )
     inference_component_call_mock = mocker.patch(
-        "recommender.engines.base.base_inference_component.BaseInferenceComponent.__call__"
+        "recommender.engines.base.base_inference_component.MLEngineInferenceComponent.__call__"
     )
     deserializer_mock = mocker.patch(
         "recommender.services.deserializer.Deserializer.deserialize_recommendation"

--- a/tests/engines/ncf/inference/test_ncf_inference_component.py
+++ b/tests/engines/ncf/inference/test_ncf_inference_component.py
@@ -49,6 +49,8 @@ def test_ncf_inference_component(
 
     for panel_id_version, K in list(PANEL_ID_TO_K.items()):
         ncf_inference_component = NCFInferenceComponent(K)
+        assert isinstance(ncf_inference_component, NCFInferenceComponent)
+        assert isinstance(ncf_inference_component.engine_name, str)
         user = random.choice(list(User.objects))
 
         context = {
@@ -71,51 +73,6 @@ def test_ncf_inference_component(
 
         services_ids_2 = ncf_inference_component(context)
         assert services_ids_1 == services_ids_2
-
-    for panel_id_version, K in list(PANEL_ID_TO_K.items()):
-        ncf_inference_component = NCFInferenceComponent(K)
-
-        context = {
-            "panel_id": panel_id_version,
-            "elastic_services": elastic_services,
-            "search_data": {},
-            "user_id": -1,
-        }
-
-        services_ids_1 = ncf_inference_component(context)
-        assert isinstance(
-            ncf_inference_component.neural_cf_model, NeuralCollaborativeFilteringModel
-        )
-
-        assert isinstance(services_ids_1, list)
-        assert len(services_ids_1) == PANEL_ID_TO_K.get(context["panel_id"])
-        assert all([isinstance(service_id, int) for service_id in services_ids_1])
-        assert all(service in elastic_services for service in services_ids_1)
-
-        services_ids_2 = ncf_inference_component(context)
-        assert services_ids_1 != services_ids_2
-
-    for panel_id_version, K in list(PANEL_ID_TO_K.items()):
-        ncf_inference_component = NCFInferenceComponent(K)
-
-        context = {
-            "panel_id": panel_id_version,
-            "elastic_services": elastic_services,
-            "search_data": {},
-        }
-
-        services_ids_1 = ncf_inference_component(context)
-        assert isinstance(
-            ncf_inference_component.neural_cf_model, NeuralCollaborativeFilteringModel
-        )
-
-        assert isinstance(services_ids_1, list)
-        assert len(services_ids_1) == PANEL_ID_TO_K.get(context["panel_id"])
-        assert all([isinstance(service_id, int) for service_id in services_ids_1])
-        assert all(service in elastic_services for service in services_ids_1)
-
-        services_ids_2 = ncf_inference_component(context)
-        assert services_ids_1 != services_ids_2
 
     with pytest.raises(InvalidRecommendationPanelIDError):
         NCFInferenceComponent(K=-1)

--- a/tests/engines/random/inference/test_random_inference_component.py
+++ b/tests/engines/random/inference/test_random_inference_component.py
@@ -1,0 +1,98 @@
+# pylint: disable-all
+
+import random
+import pytest
+from recommender.engines.random.inference.random_inference_component import (
+    RandomInferenceComponent,
+)
+from recommender.engines.panel_id_to_services_number_mapping import PANEL_ID_TO_K
+from recommender.models import Service, User
+from recommender.errors import (
+    InsufficientRecommendationSpaceError,
+    InvalidRecommendationPanelIDError,
+)
+
+
+@pytest.mark.parametrize("ver", ["v1", "v2"])
+def test_random_inference_component(mongo, generate_users_and_services, ver):
+    K = PANEL_ID_TO_K[ver]
+    inference_component = RandomInferenceComponent(K=K)
+    assert isinstance(inference_component, RandomInferenceComponent)
+    assert isinstance(inference_component.engine_name, str)
+
+    elastic_services = [service.id for service in Service.objects]
+    user = random.choice(list(User.objects))
+
+    contexts = [
+        {
+            "panel_id": ver,
+            "elastic_services": elastic_services,
+            "search_data": {},
+            "user_id": user.id,
+        },
+        {
+            "panel_id": ver,
+            "elastic_services": elastic_services,
+            "search_data": {},
+            "user_id": -1,
+        },
+        {
+            "panel_id": ver,
+            "elastic_services": elastic_services,
+            "search_data": {},
+        },
+        {
+            "panel_id": ver,
+            "elastic_services": elastic_services,
+        },
+        {
+            "elastic_services": elastic_services,
+        },
+    ]
+
+    for context in contexts:
+        services_ids_1 = inference_component(context)
+        _check_proper(services_ids_1, elastic_services, ver)
+
+        services_ids_2 = inference_component(context)
+        _check_proper(services_ids_2, elastic_services, ver)
+        assert services_ids_1 != services_ids_2
+
+    # 2. case InsufficientRecommendationSpaceError - in all cases
+    contexts = [
+        {"elastic_services": None},
+        {"elastic_services": []},
+        {"elastic_services": ()},
+        {"elastic_services": [random.choice(elastic_services)]},
+    ]
+
+    for context in contexts:
+        with pytest.raises(InsufficientRecommendationSpaceError):
+            inference_component(context)
+
+    # 3. case InsufficientRecommendationSpaceError - depends on the version
+    contexts = [
+        {"elastic_services": random.choices(elastic_services, k=2)},
+        {"elastic_services": random.choices(elastic_services, k=3)},
+    ]
+
+    for context in contexts:
+        if ver == "v1" and len(context["elastic_services"]) == 2:
+            with pytest.raises(InsufficientRecommendationSpaceError):
+                inference_component(context)
+        else:
+            services_ids_1 = inference_component(context)
+            _check_proper(services_ids_1, elastic_services, ver)
+
+
+def _check_proper(services, elastic_services, ver):
+    assert isinstance(services, list)
+    assert len(services) == PANEL_ID_TO_K.get(ver)
+    assert all([isinstance(service_id, int) for service_id in services])
+    assert all(service in elastic_services for service in services)
+
+
+@pytest.mark.parametrize("K", [0, 1, 4, 5])
+def test_incorrect_init_of_anonymous_inference_component(mongo, K):
+    with pytest.raises(InvalidRecommendationPanelIDError):
+        RandomInferenceComponent(K=K)

--- a/tests/engines/rl/inference/test_rl_inference_component.py
+++ b/tests/engines/rl/inference/test_rl_inference_component.py
@@ -6,13 +6,15 @@ import pytest
 from recommender import User
 from recommender.engines.panel_id_to_services_number_mapping import PANEL_ID_TO_K
 from recommender.engines.rl.inference.rl_inference_component import RLInferenceComponent
-from recommender.models import Category, Service
+from recommender.models import Service
 
 
 @pytest.mark.parametrize("ver", ["v1", "v2"])
 def test_known_user(mongo, generate_users_and_services, mock_rl_pipeline_exec, ver):
     K = PANEL_ID_TO_K[ver]
     inference_component = RLInferenceComponent(K=K)
+    assert isinstance(inference_component, RLInferenceComponent)
+    assert isinstance(inference_component.engine_name, str)
 
     user = random.choice(list(User.objects))
     elastic_services = [service.id for service in Service.objects]
@@ -33,35 +35,6 @@ def test_known_user(mongo, generate_users_and_services, mock_rl_pipeline_exec, v
 
     services_ids_2 = inference_component(context)
     assert services_ids_1 == services_ids_2
-
-
-@pytest.mark.parametrize("ver", ["v1", "v2"])
-def test_unknown_user(mongo, generate_users_and_services, mock_rl_pipeline_exec, ver):
-    K = PANEL_ID_TO_K[ver]
-    inference_component = RLInferenceComponent(K=K)
-    elastic_services = [service.id for service in Service.objects]
-
-    contexts = [
-        {
-            "panel_id": ver,
-            "elastic_services": elastic_services,
-            "search_data": {},
-            "user_id": -1,
-        },
-        {
-            "panel_id": ver,
-            "elastic_services": elastic_services,
-            "search_data": {},
-        },
-    ]
-
-    for context in contexts:
-        services_ids_1 = inference_component(context)
-        _check_proper(services_ids_1, ver)
-
-        services_ids_2 = inference_component(context)
-        _check_proper(services_ids_2, ver)
-        assert services_ids_1 != services_ids_2
 
 
 def _check_proper(services, ver):

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,5 +1,16 @@
+# pylint: disable-all
 """Fixtures for services testing"""
 import pytest
+from _pytest.fixtures import fixture
+
+from recommender.engines.random.inference.random_inference_component import (
+    RandomInferenceComponent,
+)
+from recommender.engines.ncf.inference.ncf_inference_component import (
+    NCFInferenceComponent,
+)
+from recommender.engines.rl.inference.rl_inference_component import RLInferenceComponent
+from tests.factories.marketplace import ServiceFactory
 
 
 @pytest.fixture
@@ -47,3 +58,26 @@ def user_action_json_dict():
         },
         "action": {"type": "button", "text": "Details", "order": True},
     }
+
+
+@fixture
+def get_engines():
+    engines = {
+        RLInferenceComponent.engine_name: RLInferenceComponent,
+        NCFInferenceComponent.engine_name: NCFInferenceComponent,
+        RandomInferenceComponent.engine_name: RandomInferenceComponent,
+    }
+    return engines
+
+
+@pytest.fixture
+def create_services(mongo):
+    services = [
+        ServiceFactory(status="published"),
+        ServiceFactory(status="unverified"),
+        ServiceFactory(status="unverified"),
+        ServiceFactory(status="errored"),
+        ServiceFactory(status="deleted"),
+        ServiceFactory(status="draft"),
+    ]
+    return services

--- a/tests/services/test_deserializer.py
+++ b/tests/services/test_deserializer.py
@@ -10,7 +10,6 @@ from tests.factories.marketplace.platform import PlatformFactory
 from tests.factories.marketplace.provider import ProviderFactory
 from tests.factories.marketplace.scientific_domain import ScientificDomainFactory
 from tests.factories.marketplace.target_user import TargetUserFactory
-from tests.endpoints.test_recommendations import recommendation_data
 
 
 def test_recommendation_deserialization(mongo, recommendation_json_dict):

--- a/tests/services/test_fts.py
+++ b/tests/services/test_fts.py
@@ -1,5 +1,4 @@
 # pylint: disable-all
-import pytest
 
 from recommender.models import Service, SearchData
 from recommender.services.fts import (
@@ -14,19 +13,6 @@ from tests.factories.marketplace.platform import PlatformFactory
 from tests.factories.marketplace.provider import ProviderFactory
 from tests.factories.marketplace.scientific_domain import ScientificDomainFactory
 from tests.factories.marketplace.target_user import TargetUserFactory
-
-
-@pytest.fixture
-def create_services(mongo):
-    services = [
-        ServiceFactory(status="published"),
-        ServiceFactory(status="unverified"),
-        ServiceFactory(status="unverified"),
-        ServiceFactory(status="errored"),
-        ServiceFactory(status="deleted"),
-        ServiceFactory(status="draft"),
-    ]
-    return services
 
 
 def test_filter_services(mongo, mocker):


### PR DESCRIPTION
closes #370 

Changes:
- New engine called "random" is added - its responsible for serving recommendations to anonymous users,
- New engine is added in such a way that its further development will be easy and well structured (a new pipeline is created)
- NCF and RL are no longer "responsible" for serving recommendations to anonymous users - this functionality has been abstracted to the new engine,
- What is really game-changing is that from now, even if there will be no ML engine saved (for example during training), recommendations will be served using the "random" engine!

Actions after this PR:
- create migrations that will change "engine_version" of recommendations documents from "NCF" and "RL to "random" for documents that do not have user. 