### PR TITLE
[#406] Publish recommendations to databus

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,18 +222,21 @@ present in the project root directory. Details:
 - `SENTRY_RELEASE` - human-readable release name - it's optional and it can be a free-form string. If not specified, Sentry automatically set it based on the commit revision number.
 - `TRAINING_DEVICE` - the device used for training of neural networks: `cuda` for GPU support or `cpu` (note: `cuda` support is experimental and works only in Jupyter notebook `neural_cf` - not in the recommender dev/prod/test environment)
 - `DEFAULT_RECOMMENDATION_ALG` - the version of the recommender engine (one of `NCF`, `RL`, `random`) - Whenever request handling or celery task need this variable, it is dynamically loaded from the .env file, so you can change it during flask server runtime.
-- `RS_SUBSCRIBER_HOST` - the address of your JMS provider (optional)
-- `RS_SUBSCRIBER_PORT` - the port of your JMS provider (optional)
-- `RS_SUBSCRIBER_USERNAME` - your login to the JMS provider (optional)
-- `RS_SUBSCRIBER_PASSWORD` - your password to the JMS provider (optional)
-- `RS_SUBSCRIBER_TOPIC` - topic on which subscriber listens to jms (optional)
-- `RS_SUBSCRIBER_SUBSCRIPTION_ID` - subscription id of the jms subscriber (optional)
-- `RS_SUBSCRIBER_SSL` - whether to use ssl when connecting to jms (optional) (accepted values `0` or `1`, `yes` or `no`)
-- `TEST_RS_SUBSCRIBER_HOST` - same as `RS_SUBSCRIBER_HOST` but used when testing via `pytest`  (default: `127.0.0.1`)
-- `TEST_RS_SUBSCRIBER_PORT` - same as `RS_SUBSCRIBER_PORT` but used when testing via `pytest` (default: `61613`)
-- `TEST_RS_SUBSCRIBER_USERNAME` - same as `RS_SUBSCRIBER_USERNAME` but used when testing via `pytest` (default: `guest`)
-- `TEST_RS_SUBSCRIBER_PASSWORD` - same as `RS_SUBSCRIBER_PASSWORD` but used when testing via `pytest` (default: `guest`)
-- `TEST_RS_SUBSCRIBER_TOPIC` - same as `RS_SUBSCRIBER_TOPIC` but used when testing via `pytest` (default: `topic/user_actions_test`)
+- `RS_DATABUS_HOST` - the address of your JMS provider (default: `127.0.0.1`)
+- `RS_DATABUS_USERNAME` - your login to the JMS provider (default: `admin`, placeholder for the real password)
+- `RS_DATABUS_PASSWORD` - your password to the JMS provider (default: `admin`, placeholder for the real password)
+- `RS_DATABUS_PORT` - the port of your JMS provider (default: `61613`)
+- `RS_DATABUS_SUBSCRIPTION_TOPIC` - topic on which subscriber listens to jms (default: `/topic/user_actions`)
+- `RS_DATABUS_PUBLISH_TOPIC` - name of the topic to publish the recommendations on the JMS host (default: `/topic/recommendations`)
+- `RS_DATABUS_SUBSCRIPTION_ID` - subscription id of the jms subscriber (optional)
+- `RS_DATABUS_SSL` - whether to use ssl when connecting to jms (default: 1) (accepted values `0` or `1`, `yes` or `no`)
+- `TEST_RS_DATABUS_HOST` - same as `RS_DATABUS_HOST` but used when testing via `pytest`  (default: `127.0.0.1`)
+- `TEST_RS_DATABUS_PORT` - same as `RS_DATABUS_PORT` but used when testing via `pytest` (default: `61613`)
+- `TEST_RS_DATABUS_USERNAME` - same as `RS_DATABUS_USERNAME` but used when testing via `pytest` (default: `admin`, default password for the stomp docker image)
+- `TEST_RS_DATABUS_PASSWORD` - same as `RS_DATABUS_PASSWORD` but used when testing via `pytest` (default: `admin`, default password for the stomp docker image)
+- `TEST_RS_DATABUS_SUBSCRIPTION_TOPIC` - same as `RS_DATABUS_SUBSCRIPTION_TOPIC` but used when testing via `pytest` (default: `topic/user_actions_test`)
+- `TEST_RS_DATABUS_PUBLISH_TOPIC` - same as `RS_DATABUS_PUBLISH_TOPIC` but used when testing via `pytest` (default: `topic/recommendations_test`)
+- 
 
 NOTE: All the above variables have reasonable defaults, so if you want you can just have your .env file empty.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,10 @@ services:
     - redis:/data
 
   rabbitmq:
-    image: itzg/rabbitmq-stomp:latest
+    image: rmohr/activemq
     ports:
       - ${RABBIT_HOST:-127.0.0.1:61613}:61613
+      - ${RABBIT_HOST:-127.0.0.1:8161}:8161
 
 volumes:
   redis:

--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -97,42 +97,42 @@ def _register_commands(app, env: str):
     )
     @click.option(
         "--host",
-        envvar="RS_SUBSCRIBER_HOST",
-        required=True,
+        envvar="RS_DATABUS_HOST",
+        default="127.0.0.1",
         show_default=True,
         show_envvar=True,
     )
     @click.option(
         "--port",
         default=61613,
-        envvar="RS_SUBSCRIBER_PORT",
+        envvar="RS_DATABUS_PORT",
         show_default=True,
         show_envvar=True,
     )
     @click.option(
         "--username",
-        default="guest",
-        envvar="RS_SUBSCRIBER_USERNAME",
+        default="admin",
+        envvar="RS_DATABUS_USERNAME",
         show_default=True,
         show_envvar=True,
     )
     @click.option(
         "--password",
-        default="guest",
-        envvar="RS_SUBSCRIBER_PASSWORD",
+        default="admin",
+        envvar="RS_DATABUS_PASSWORD",
         show_default=True,
         show_envvar=True,
     )
     @click.option(
         "--topic",
         default="/topic/user_actions",
-        envvar="RS_SUBSCRIBER_TOPIC",
+        envvar="RS_DATABUS_SUBSCRIPTION_TOPIC",
         show_default=True,
         show_envvar=True,
     )
     @click.option(
         "--subscription-id",
-        envvar="RS_SUBSCRIBER_SUBSCRIPTION_ID",
+        envvar="RS_DATABUS_SUBSCRIPTION_ID",
         help="Subscription id should be unique. "
         "If not specified random string will be generated",
         show_envvar=True,
@@ -140,7 +140,7 @@ def _register_commands(app, env: str):
     @click.option(
         "--ssl/--no-ssl",
         default=True,
-        envvar="RS_SUBSCRIBER_SSL",
+        envvar="RS_DATABUS_SSL",
         show_envvar=True,
     )
     def tmp_subscribe(host, port, username, password, topic, subscription_id, ssl):

--- a/recommender/api/endpoints/recommendations.py
+++ b/recommender/api/endpoints/recommendations.py
@@ -13,6 +13,7 @@ from recommender.api.schemas.recommendation import (
 from recommender.services.provide_service_ctx import service_ctx
 from recommender.services.deserializer import deserialize_recommendation
 from recommender.services.engine_selector import load_engine
+from recommender.tasks import send_recommendation_to_databus
 from logger_config import get_logger
 
 api = Namespace("recommendations", "Endpoint used for getting recommendations")
@@ -46,6 +47,9 @@ class Recommendation(Resource):
                 "scores": scores,
                 "engine_version": json_dict.get("engine_version"),
             }
+
+            if json_dict.get("client_id") == "marketplace":
+                send_recommendation_to_databus.delay(json_dict, response)
 
         except InsufficientRecommendationSpaceError:
             logger.error(InsufficientRecommendationSpaceError().message())

--- a/settings.py
+++ b/settings.py
@@ -24,6 +24,17 @@ class Config:
     RESTPLUS_MASK_SWAGGER = False
     REDIS_HOST = f"redis://{os.environ.get('REDIS_HOST', '127.0.0.1:6379')}"
     TRAINING_DEVICE = get_device("TRAINING_DEVICE")
+    RS_DATABUS_HOST = os.environ.get("RS_DATABUS_HOST", "127.0.0.1")
+    RS_DATABUS_PORT = int(os.environ.get("RS_DATABUS_PORT", 61613))
+    RS_DATABUS_USERNAME = os.environ.get("RS_DATABUS_USERNAME", "admin")
+    RS_DATABUS_PASSWORD = os.environ.get("RS_DATABUS_PASSWORD", "admin")
+    RS_DATABUS_SSL = not os.environ.get("RS_DATABUS_SSL") in ["0", "no"]
+    RS_DATABUS_PUBLISH_TOPIC = os.environ.get(
+        "RS_DATABUS_PUBLISH_TOPIC", "/topic/recommendations"
+    )
+    RS_DATABUS_SUBSCRIPTION_TOPIC = os.environ.get(
+        "RS_DATABUS_SUBSCRIPTION_TOPIC", "/topic/user_actions"
+    )
 
 
 class ProductionConfig(Config):
@@ -49,6 +60,16 @@ class TestingConfig(Config):
 
     TESTING = True
     MONGODB_HOST = f"mongodb://{os.environ.get('MONGODB_HOST', '127.0.0.1:27017')}/test"
+    RS_DATABUS_HOST = os.environ.get("TEST_RS_DATABUS_HOST", "127.0.0.1")
+    RS_DATABUS_PORT = int(os.environ.get("TEST_RS_DATABUS_PORT", 61613))
+    RS_DATABUS_USERNAME = os.environ.get("TEST_RS_DATABUS_USERNAME", "admin")
+    RS_DATABUS_PASSWORD = os.environ.get("TEST_RS_DATABUS_PASSWORD", "admin")
+    RS_DATABUS_PUBLISH_TOPIC = os.environ.get(
+        "TEST_RS_DATABUS_PUBLISH_TOPIC", "/topic/recommendations_test"
+    )
+    RS_DATABUS_SUBSCRIPTION_TOPIC = os.environ.get(
+        "TEST_RS_DATABUS_SUBSCRIPTION_TOPIC", "topic/user_actions_test"
+    )
 
 
 config_by_name = dict(

--- a/tests/endpoints/conftest.py
+++ b/tests/endpoints/conftest.py
@@ -146,29 +146,3 @@ def recommendation_data_with_aai_uid():
             "target_users": [1],
         },
     }
-
-
-@pytest.fixture
-def recommendation_data_with_aai_uid():
-    return {
-        "aai_uid": "abc@egi.eu",
-        "unique_id": "5642c351-80fe-44cf-b606-304f2f338122",
-        "timestamp": "2021-03-18T18:49:55.006Z",
-        "visit_id": "202090a4-de4c-4230-acba-6e2931d9e37c",
-        "page_id": "some_page_identifier",
-        "panel_id": "v1",
-        "engine_version": "NCF",
-        "candidates": [1, 2, 3],
-        "search_data": {
-            "q": "Cloud GPU",
-            "categories": [1],
-            "geographical_availabilities": ["PL"],
-            "order_type": "open_access",
-            "providers": [1],
-            "rating": "5",
-            "related_platforms": [1],
-            "scientific_domains": [1],
-            "sort": "_score",
-            "target_users": [1],
-        },
-    }

--- a/tests/endpoints/test_recommendations.py
+++ b/tests/endpoints/test_recommendations.py
@@ -3,53 +3,68 @@
 import json
 from copy import deepcopy
 
+import pytest
+
 from recommender.engines.explanations import Explanation
 
 
-def test_recommendations(
-    client, mocker, recommendation_data, recommendation_data_with_aai_uid
-):
+@pytest.mark.parametrize(
+    "recc_data_fixture", ["recommendation_data", "recommendation_data_with_aai_uid"]
+)
+def test_recommendations(client, mocker, recc_data_fixture, request):
+    recc_data = request.getfixturevalue(recc_data_fixture)
 
-    for recc_data in [recommendation_data, recommendation_data_with_aai_uid]:
-        _inference_component_init_mock = mocker.patch(
-            "recommender.engines.base.base_inference_component.MLEngineInferenceComponent.__init__"
+    _inference_component_init_mock = mocker.patch(
+        "recommender.engines.base.base_inference_component.MLEngineInferenceComponent.__init__"
+    )
+    inference_component_call_mock = mocker.patch(
+        "recommender.engines.base.base_inference_component.MLEngineInferenceComponent.__call__"
+    )
+    deserializer_mock = mocker.patch(
+        "recommender.services.deserializer.Deserializer.deserialize_recommendation"
+    )
+    send_recommendation_to_databus_mock = mocker.patch(
+        "recommender.tasks.send_recommendation_to_databus.delay"
+    )
+
+    mock_recommended_services_ids = [1, 2, 3]
+    mock_scores = [0.7, 0.2, 0.1]
+    mock_explanations = 3 * [Explanation(long="mock_long", short="mock_short")]
+    inference_component_call_mock.return_value = (
+        mock_recommended_services_ids,
+        mock_scores,
+        mock_explanations,
+    )
+
+    response = client.post(
+        "/recommendations",
+        data=json.dumps(recc_data),
+        content_type="application/json",
+    )
+
+    deserializer_data = deepcopy(recc_data)
+    deserializer_data["services"] = mock_recommended_services_ids
+
+    inference_component_call_mock.assert_called_once_with(recc_data)
+    deserializer_mock.assert_called_once_with(deserializer_data)
+
+    mock_explanations_long, mock_explanations_short = [
+        list(t) for t in list(zip(*[(e.long, e.short) for e in mock_explanations]))
+    ]
+
+    assert response.get_json() == {
+        "panel_id": recc_data["panel_id"],
+        "recommendations": mock_recommended_services_ids,
+        "explanations": mock_explanations_long,
+        "explanations_short": mock_explanations_short,
+        "scores": mock_scores,
+        "engine_version": recc_data["engine_version"],
+    }
+
+    # AAI uid fixture contains client_id != marketplace, so it shouldn't create a celery task
+    if recc_data_fixture == "recommendation_data_with_aai_uid":
+        send_recommendation_to_databus_mock.assert_not_called()
+    else:
+        send_recommendation_to_databus_mock.assert_called_once_with(
+            recc_data, response.get_json()
         )
-        inference_component_call_mock = mocker.patch(
-            "recommender.engines.base.base_inference_component.MLEngineInferenceComponent.__call__"
-        )
-        deserializer_mock = mocker.patch(
-            "recommender.services.deserializer.Deserializer.deserialize_recommendation"
-        )
-        mock_recommended_services_ids = [1, 2, 3]
-        mock_scores = [0.7, 0.2, 0.1]
-        mock_explanations = 3 * [Explanation(long="mock_long", short="mock_short")]
-        inference_component_call_mock.return_value = (
-            mock_recommended_services_ids,
-            mock_scores,
-            mock_explanations,
-        )
-
-        response = client.post(
-            "/recommendations",
-            data=json.dumps(recc_data),
-            content_type="application/json",
-        )
-
-        deserializer_data = deepcopy(recc_data)
-        deserializer_data["services"] = mock_recommended_services_ids
-
-        inference_component_call_mock.assert_called_once_with(recc_data)
-        deserializer_mock.assert_called_once_with(deserializer_data)
-
-        mock_explanations_long, mock_explanations_short = [
-            list(t) for t in list(zip(*[(e.long, e.short) for e in mock_explanations]))
-        ]
-
-        assert response.get_json() == {
-            "panel_id": recc_data["panel_id"],
-            "recommendations": mock_recommended_services_ids,
-            "explanations": mock_explanations_long,
-            "explanations_short": mock_explanations_short,
-            "scores": mock_scores,
-            "engine_version": recc_data["engine_version"],
-        }


### PR DESCRIPTION
Deployment notice. Following ENV variables need to be properly provided for each environment, **if the defaults are invalid** (`host`, `user` and `password` will 100% be invalid):

- `RS_DATABUS_HOST` - the address of your JMS provider (default: `127.0.0.1`)
- `RS_DATABUS_USERNAME` - your login to the JMS provider (default: `admin`, placeholder for the real password)
- `RS_DATABUS_PASSWORD` - your password to the JMS provider (default: `admin`, placeholder for the real password)
- `RS_DATABUS_PORT` - the port of your JMS provider (default: `61613`)
- `RS_DATABUS_SUBSCRIPTION_TOPIC` - topic on which subscriber listens to jms (default: `/topic/user_actions`)
- `RS_DATABUS_PUBLISH_TOPIC` - name of the topic to publish the recommendations on the JMS host (default: `/topic/recommendations`)
- `RS_DATABUS_SSL` - whether to use ssl when connecting to jms (default: 1) (accepted values `0` or `1`, `yes` or `no`)

Additionally the following ENV variables have been renamed:
- `RS_SUBSCRIBER_HOST -> RS_DATABUS_HOST`
- `RS_SUBSCRIBER_PORT -> RS_DATABUS_PORT`
- `RS_SUBSCRIBER_PASSWORD -> RS_DATABUS_PASSWORD`
- `RS_SUBSCRIBER_USERNAME -> RS_DATABUS_USERNAME`
- `RS_SUBSCRIBER_TOPIC-> RS_DATABUS_SUBSCRIPTION_TOPIC`
- `RS_SUBSCRIBER_SUBSCRIPTION_ID -> RS_DATABUS_SUBSCRIPTION_ID`
- `RS_SUBSCRIBER_SSL -> RS_DATABUS_SSL`
- `TEST_RS_SUBSCRIBER_HOST -> TEST_RS_DATABUS_HOST`
- `TEST_RS_SUBSCRIBER_PORT -> TEST_RS_DATABUS_PORT`
- `TEST_RS_SUBSCRIBER_USERNAME -> TEST_RS_DATABUS_USERNAME` 
- `TEST_RS_SUBSCRIBER_PASSWORD -> TEST_ RS_DATABUS_PASSWORD`
- `TEST_RS_SUBSCRIBER_TOPIC -> TEST_RS_DATABUS_SUBSCRIPTION_TOPIC`

JMS host, port, user, password and ssl are shared between the old subscription JMS cli and new JMS publisher.

Tested on local env.